### PR TITLE
Fix line feeds, alignment, whitespace, tables and column mode images

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -106,6 +106,8 @@ See the chapter [Handling text](text.md) for more information about code pages.
 
 Print a string of text. Word are wrapped automatically at the width specified by the `columns` property set at initialisation. 
 
+Multiple calls to `text()` continue on the same line. A newline character in the text ends the current line, and the text after it, from the same call or a later one, continues on the next line.
+
 ```js
 let result = encoder
     .text('The quick brown fox jumps over the lazy dog')

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -468,6 +468,8 @@ The first parameter is an object with additional configuration options.
 
 The second parameter is the content of the box and it can be a string, or a callback function.
 
+The width of the box is measured in characters of the size that is active when the box is created, and the content of the box inherits the styles and size, in the same way as the cells of a table.
+
 For example:
 
 ```js

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -425,6 +425,8 @@ The value can either be a string or a callback function.
 
 If you want to style text inside of a cell, can use the callback function instead. The first parameter of the called function contains the encoder object which you can use to chain additional commands.
 
+Cells inherit the bold, italic, underline and invert styles that are active when the table is created. Changing one of these styles inside a cell only applies to that cell, the other cells keep the inherited style.
+
 ```js
 [
     /* Row one, with two columns */

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -470,7 +470,7 @@ For example:
 let result = encoder
     .box(
         { width: 30, align: 'right', style: 'double', marginLeft: 10 }, 
-        'The quick brown fox jumps over the lazy dog';o50[p49]
+        'The quick brown fox jumps over the lazy dog'
     )
     .encode()
 ```

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -437,7 +437,7 @@ Cells inherit the bold, italic, underline and invert styles that are active when
 ]
 ```
 
-Text inside a cell can have a different width or size. The width of a column is measured in single width characters, so a column with a width of 10 fits 5 double width characters on a line, after which the text wraps. Characters of different widths can be mixed on the same line.
+The width of a column is measured in characters of the size that is active when the table is created. Cells inherit that size. When a cell changes the size, the number of characters that fit changes with it: a column with a width of 10 in a table at double size fits 10 double width characters, or 20 single width characters after `size(1)` in the cell. Characters of different sizes can be mixed on the same line, and the padding of a cell is always printed in single width spaces.
 
 ```js
 [
@@ -448,7 +448,7 @@ Text inside a cell can have a different width or size. The width of a column is 
 ]
 ```
 
-If the width or size is changed before calling `table()`, the whole table is printed at that size and the column widths count characters at that size. A table with a total width of 24 characters printed at double width takes up 48 columns of paper.
+A table with a total width of 24 characters created at double size takes up 48 columns of paper.
 
 <br>
 

--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -400,7 +400,7 @@ The table function takes two parameters.
 
 The first parameter is an array of column definitions. Each column can have the folowing properties:
 
-- `width`:  determines the width of the column. 
+- `width`:  determines the width of the column in characters. The total width of all columns, including margins, must fit on the paper, otherwise an error is thrown.
 - `marginLeft` and `marginRight`: set a margin to the left and right of the column. 
 - `align`: sets the horizontal alignment of the text in the column and can either be `left` or `right`.
 - `verticalAlign`: sets the vertical alignment of the text in the column and can either be `top` or `bottom`.
@@ -432,6 +432,19 @@ If you want to style text inside of a cell, can use the callback function instea
     ],
 ]
 ```
+
+Text inside a cell can have a different width or size. The width of a column is measured in single width characters, so a column with a width of 10 fits 5 double width characters on a line, after which the text wraps. Characters of different widths can be mixed on the same line.
+
+```js
+[
+    [ 
+        (encoder) => encoder.size(2).text('Total'),
+        (encoder) => encoder.text('€ ').size(2).text('250,75')
+    ],
+]
+```
+
+If the width or size is changed before calling `table()`, the whole table is printed at that size and the column widths count characters at that size. A table with a total width of 24 characters printed at double width takes up 48 columns of paper.
 
 <br>
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -130,6 +130,20 @@ let encoder = new ReceiptPrinterEncoder({
 
 <br>
 
+### Feed after block
+
+Images, barcodes, QR codes and PDF417 codes advance the paper by themselves. By default the encoder still sends a line feed after them, which results in an empty line below the image or code.
+
+To print the content that follows directly below the image or code, set the `feedAfterBlock` option to `false`. You can then use `newline()` to add space where you want it.
+
+```js
+let encoder = new ReceiptPrinterEncoder({
+    feedAfterBlock: false
+});
+```
+
+<br>
+
 ### Newline
 
 Most printers use a combination of a newline and carriage return to move the text position to the beginning of the next line. 

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -104,3 +104,25 @@ import ReceiptPrinterEncoder from 'npm:@point-of-sale/receipt-printer-encoder';
 
 let encoder = new ReceiptPrinterEncoder();
 ```
+
+<br>
+
+### Using with React Native and Expo
+
+This library and its dependencies use `structuredClone()`, which is part of the web platform and Node, but is not provided by React Native or the Hermes engine. Without it, creating an encoder fails with an error like `Property 'structuredClone' doesn't exist`.
+
+Install a polyfill and make it available as a global before importing this library, for example in the entry point of your app:
+
+```sh
+npm install @ungap/structured-clone
+```
+
+```js
+import structuredClone from '@ungap/structured-clone';
+
+if (typeof globalThis.structuredClone !== 'function') {
+    globalThis.structuredClone = structuredClone;
+}
+```
+
+The `image()` function also needs a way to read pixels, see the [image command](commands.md#image) for the input types it accepts and the `createCanvas` option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@rollup/plugin-commonjs": "^24.1.0",
                 "@rollup/plugin-node-resolve": "^15.0.2",
                 "@rollup/plugin-terser": "^0.4.1",
-                "canvas": "^2.11.2",
+                "canvas": "^3.0.0",
                 "chai": "^4.3.7",
                 "eslint": "^8.39.0",
                 "eslint-config-google": "^0.14.0",
@@ -217,26 +217,6 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "dev": true
         },
-        "node_modules/@mapbox/node-pre-gyp": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-            "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
-            "dev": true,
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "make-dir": "^3.1.0",
-                "node-fetch": "^2.6.7",
-                "nopt": "^5.0.0",
-                "npmlog": "^5.0.1",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.11"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -384,12 +364,6 @@
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
-        "node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true
-        },
         "node_modules/acorn": {
             "version": "8.8.2",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -409,18 +383,6 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
             }
         },
         "node_modules/ajv": {
@@ -485,25 +447,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/aproba": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-            "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "dev": true
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-            "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "dev": true,
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -525,6 +468,27 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -532,6 +496,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/brace-expansion": {
@@ -561,6 +537,31 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -602,18 +603,18 @@
             }
         },
         "node_modules/canvas": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-            "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+            "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "nan": "^2.17.0",
-                "simple-get": "^3.0.3"
+                "node-addon-api": "^7.0.0",
+                "prebuild-install": "^7.1.3"
             },
             "engines": {
-                "node": ">=6"
+                "node": "^18.12.0 || >= 20.9.0"
             }
         },
         "node_modules/canvas-dither": {
@@ -709,13 +710,11 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
+            "license": "ISC"
         },
         "node_modules/cliui": {
             "version": "7.0.4",
@@ -746,15 +745,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true,
-            "bin": {
-                "color-support": "bin.js"
-            }
-        },
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -771,12 +761,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
-        },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "dev": true
         },
         "node_modules/cross-spawn": {
@@ -823,15 +807,19 @@
             }
         },
         "node_modules/decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/deep-eql": {
@@ -844,6 +832,16 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -861,17 +859,12 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "dev": true
-        },
         "node_modules/detect-libc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
             }
@@ -902,6 +895,16 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -1086,6 +1089,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "dev": true,
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1181,29 +1194,12 @@
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
             "dev": true
         },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "dev": true,
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
+            "license": "MIT"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -1231,26 +1227,6 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
-        "node_modules/gauge": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-            "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-            "dev": true,
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.2",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.1",
-                "object-assign": "^4.1.1",
-                "signal-exit": "^3.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1268,6 +1244,13 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/glob": {
             "version": "8.1.0",
@@ -1363,12 +1346,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "dev": true
-        },
         "node_modules/he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1378,18 +1355,26 @@
                 "he": "bin/he"
             }
         },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "5.2.4",
@@ -1440,6 +1425,13 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -1678,18 +1670,6 @@
                 "get-func-name": "^2.0.0"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -1702,37 +1682,14 @@
                 "node": ">=12"
             }
         },
-        "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -1750,51 +1707,22 @@
                 "node": "*"
             }
         },
-        "node_modules/minipass": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "dev": true,
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
+            "license": "MIT"
         },
         "node_modules/mocha": {
             "version": "10.2.0",
@@ -1925,12 +1853,6 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
-        "node_modules/nan": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-            "dev": true
-        },
         "node_modules/nanoid": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -1943,72 +1865,43 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+        "node_modules/node-abi": {
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "whatwg-url": "^5.0.0"
+                "semver": "^7.3.5"
             },
             "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+                "node": ">=10"
             }
         },
-        "node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "dev": true,
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
+            "license": "MIT"
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npmlog": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-            "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "dev": true,
-            "dependencies": {
-                "are-we-there-yet": "^2.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^3.0.0",
-                "set-blocking": "^2.0.0"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -2144,6 +2037,34 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2151,6 +2072,17 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "node_modules/punycode": {
@@ -2191,11 +2123,38 @@
                 "safe-buffer": "^5.1.0"
             }
         },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -2403,13 +2362,11 @@
             ]
         },
         "node_modules/semver": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-            "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2425,12 +2382,6 @@
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
-        },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "dev": true
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -2453,12 +2404,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
-        },
         "node_modules/simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2477,15 +2422,31 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/simple-get": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -2520,6 +2481,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -2586,21 +2548,34 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/tar": {
-            "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+        "node_modules/tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=6"
             }
         },
         "node_modules/terser": {
@@ -2639,11 +2614,18 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2705,23 +2687,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -2736,15 +2703,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/wide-align": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "dev": true,
-            "dependencies": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "node_modules/word-wrap": {
@@ -2793,12 +2751,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -2998,23 +2950,6 @@
                 }
             }
         },
-        "@mapbox/node-pre-gyp": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
-            "integrity": "sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==",
-            "dev": true,
-            "requires": {
-                "detect-libc": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "make-dir": "^3.1.0",
-                "node-fetch": "^2.6.7",
-                "nopt": "^5.0.0",
-                "npmlog": "^5.0.1",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.11"
-            }
-        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3108,12 +3043,6 @@
             "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "dev": true
-        },
         "acorn": {
             "version": "8.8.2",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -3126,15 +3055,6 @@
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "requires": {}
-        },
-        "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
-            "requires": {
-                "debug": "4"
-            }
         },
         "ajv": {
             "version": "6.12.6",
@@ -3179,22 +3099,6 @@
                 "picomatch": "^2.0.4"
             }
         },
-        "aproba": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-            "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-            "dev": true
-        },
-        "are-we-there-yet": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-            "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "dev": true,
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            }
-        },
         "argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3213,11 +3117,28 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
         "binary-extensions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
+            "requires": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -3244,6 +3165,16 @@
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
+        "buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
         "buffer-from": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3269,14 +3200,13 @@
             "dev": true
         },
         "canvas": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-            "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+            "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
             "dev": true,
             "requires": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "nan": "^2.17.0",
-                "simple-get": "^3.0.3"
+                "node-addon-api": "^7.0.0",
+                "prebuild-install": "^7.1.3"
             }
         },
         "canvas-dither": {
@@ -3348,9 +3278,9 @@
             }
         },
         "chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true
         },
         "cliui": {
@@ -3379,12 +3309,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
-        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3401,12 +3325,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "dev": true
         },
         "cross-spawn": {
@@ -3436,12 +3354,12 @@
             "dev": true
         },
         "decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
             "dev": true,
             "requires": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             }
         },
         "deep-eql": {
@@ -3452,6 +3370,12 @@
             "requires": {
                 "type-detect": "^4.0.0"
             }
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -3465,16 +3389,10 @@
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true
         },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "dev": true
-        },
         "detect-libc": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true
         },
         "diff": {
@@ -3497,6 +3415,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
         },
         "escalade": {
             "version": "3.1.1",
@@ -3628,6 +3555,12 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "dev": true
+        },
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3705,25 +3638,11 @@
             "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
             "dev": true
         },
-        "fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "dev": true,
-            "requires": {
-                "minipass": "^3.0.0"
-            },
-            "dependencies": {
-                "minipass": {
-                    "version": "3.3.6",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -3744,23 +3663,6 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
-        "gauge": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-            "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-            "dev": true,
-            "requires": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.2",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.1",
-                "object-assign": "^4.1.1",
-                "signal-exit": "^3.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.2"
-            }
-        },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3771,6 +3673,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+            "dev": true
+        },
+        "github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "dev": true
         },
         "glob": {
@@ -3845,27 +3753,17 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
         },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "dev": true
-        },
         "he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
         },
-        "https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "dev": true,
-            "requires": {
-                "agent-base": "6",
-                "debug": "4"
-            }
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
         },
         "ignore": {
             "version": "5.2.4",
@@ -3903,6 +3801,12 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
         },
         "is-binary-path": {
@@ -4082,15 +3986,6 @@
                 "get-func-name": "^2.0.0"
             }
         },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "requires": {
-                "yallist": "^4.0.0"
-            }
-        },
         "magic-string": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -4100,27 +3995,10 @@
                 "@jridgewell/sourcemap-codec": "^1.4.13"
             }
         },
-        "make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
-            "requires": {
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
         "mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
             "dev": true
         },
         "minimatch": {
@@ -4132,37 +4010,16 @@
                 "brace-expansion": "^1.1.7"
             }
         },
-        "minipass": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+        "minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true
         },
-        "minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "dev": true,
-            "requires": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "dependencies": {
-                "minipass": {
-                    "version": "3.3.6",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-                    "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-                    "dev": true,
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                }
-            }
-        },
-        "mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true
         },
         "mocha": {
@@ -4271,16 +4128,16 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
-        "nan": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
-            "dev": true
-        },
         "nanoid": {
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
             "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+            "dev": true
+        },
+        "napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
             "dev": true
         },
         "natural-compare": {
@@ -4289,46 +4146,25 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node-fetch": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-            "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+        "node-abi": {
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
             "dev": true,
             "requires": {
-                "whatwg-url": "^5.0.0"
+                "semver": "^7.3.5"
             }
         },
-        "nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "dev": true,
-            "requires": {
-                "abbrev": "1"
-            }
+        "node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true
         },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
-        },
-        "npmlog": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-            "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "dev": true,
-            "requires": {
-                "are-we-there-yet": "^2.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^3.0.0",
-                "set-blocking": "^2.0.0"
-            }
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true
         },
         "once": {
@@ -4424,11 +4260,41 @@
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true
         },
+        "prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "dev": true,
+            "requires": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            }
+        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
+        },
+        "pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "2.3.0",
@@ -4449,6 +4315,26 @@
             "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
+            }
+        },
+        "rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "dependencies": {
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+                    "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+                    "dev": true
+                }
             }
         },
         "readable-stream": {
@@ -4579,13 +4465,10 @@
             "dev": true
         },
         "semver": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-            "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "6.0.1",
@@ -4595,12 +4478,6 @@
             "requires": {
                 "randombytes": "^2.1.0"
             }
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -4617,12 +4494,6 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
-        },
         "simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -4630,12 +4501,12 @@
             "dev": true
         },
         "simple-get": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+            "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
             "dev": true,
             "requires": {
-                "decompress-response": "^4.2.0",
+                "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
@@ -4712,18 +4583,29 @@
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true
         },
-        "tar": {
-            "version": "6.1.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
-            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
+        "tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
             "dev": true,
             "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^4.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
+            "requires": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
             }
         },
         "terser": {
@@ -4753,11 +4635,14 @@
                 "is-number": "^7.0.0"
             }
         },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "type-check": {
             "version": "0.4.0",
@@ -4801,22 +4686,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4824,15 +4693,6 @@
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
-            }
-        },
-        "wide-align": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "dev": true,
-            "requires": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "word-wrap": {
@@ -4868,12 +4728,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-terser": "^0.4.1",
-        "canvas": "^2.11.2",
+        "canvas": "^3.0.0",
         "chai": "^4.3.7",
         "eslint": "^8.39.0",
         "eslint-config-google": "^0.14.0",

--- a/src/languages/esc-pos.js
+++ b/src/languages/esc-pos.js
@@ -430,9 +430,10 @@ class LanguageEscPos {
      * @param {number} width        Width of the image
      * @param {number} height       Height of the image
      * @param {string} mode         Image encoding mode ('column' or 'raster')
+     * @param {number} [dpi]        Resolution of the printer in dots per inch, if known
      * @return {Array}             Array of bytes to send to the printer
      */
-  image(image, width, height, mode) {
+  image(image, width, height, mode, dpi) {
     const result = [];
 
     const getPixel = (x, y) => x < width && y < height ? (image.data[((width * y) + x) * 4] > 0 ? 0 : 1) : 0;
@@ -474,11 +475,26 @@ class LanguageEscPos {
     /* Encode images with ESC * */
 
     if (mode == 'column') {
+      /* The line spacing is set in motion units, which are not the same as dots
+         on every printer. On Epson printers the vertical motion unit is half a
+         dot by default. When the resolution is known, set the motion unit to
+         one dot, so 24 units are 24 dots and the strips of the image join up */
+
+      if (dpi) {
+        result.push(
+            {
+              type: 'motion-unit',
+              value: dpi,
+              payload: [0x1d, 0x50, dpi, dpi],
+            },
+        );
+      }
+
       result.push(
           {
             type: 'line-spacing',
             value: '24 dots',
-            payload: [0x1b, 0x33, 0x24],
+            payload: [0x1b, 0x33, 0x18],
           },
       );
 
@@ -502,6 +518,18 @@ class LanguageEscPos {
             payload: [0x1b, 0x32],
           },
       );
+
+      /* Restore the default motion units */
+
+      if (dpi) {
+        result.push(
+            {
+              type: 'motion-unit',
+              value: 'default',
+              payload: [0x1d, 0x50, 0x00, 0x00],
+            },
+        );
+      }
     }
 
     /* Encode images with GS v */

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -7,6 +7,10 @@ const STATE_TYPES = [
   'style', 'align', 'font', 'initialize', 'character-mode', 'codepage', 'line-spacing', 'motion-unit', 'raw',
 ];
 
+/* Item types that a text style applies to */
+
+const STYLED_TYPES = ['text', 'space', 'raw'];
+
 /* Item types that print a block which advances the paper by itself */
 
 const BLOCK_TYPES = ['image', 'barcode', 'qrcode', 'pdf417'];
@@ -199,11 +203,21 @@ class LineComposer {
     const restore = this.style.restore();
     const store = this.style.store();
 
+    /* Styles only apply to text, spaces and raw data. On a line without any of
+       those, such as a cut, an image or only pending state changes, the style
+       commands are left out. The style object carries the state to the next line */
+
+    const styled = buffer.some((item) => STYLED_TYPES.includes(item.type));
+
+    const before = styled ? this.#stored : [];
+    const after = styled ? store : [];
+    const items = styled ? buffer : buffer.filter((item) => item.type !== 'style');
+
     if (this.#cursor === 0 && (options.ignoreAlignment || !this.#embedded)) {
       result = this.#merge([
-        ...this.#stored,
-        ...buffer,
-        ...store,
+        ...before,
+        ...items,
+        ...after,
       ]);
     } else {
       if (this.#align === 'right') {
@@ -234,9 +248,9 @@ class LineComposer {
 
         result = this.#merge([
           {type: 'space', size: Math.max(0, this.#columns - this.#cursor)},
-          ...this.#stored,
-          ...buffer,
-          ...store,
+          ...before,
+          ...items,
+          ...after,
         ]);
       }
 
@@ -245,18 +259,18 @@ class LineComposer {
 
         result = this.#merge([
           {type: 'space', size: left},
-          ...this.#stored,
-          ...buffer,
-          ...store,
+          ...before,
+          ...items,
+          ...after,
           {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor - left) : 0},
         ]);
       }
 
       if (this.#align === 'left') {
         result = this.#merge([
-          ...this.#stored,
-          ...buffer,
-          ...store,
+          ...before,
+          ...items,
+          ...after,
           {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor) : 0},
         ]);
       }

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -114,6 +114,21 @@ class LineComposer {
   }
 
   /**
+     * Determine if a list of items contains printable content, or only
+     * commands that change the state of the printer, such as styles,
+     * fonts or alignment. Raw commands are not considered content, if
+     * they contain printable data the caller is responsible for the newline.
+     *
+     * @param  {object[]}   items   The items of a line
+     * @return {boolean}            True if the line contains printable content
+     */
+  static hasContent(items) {
+    const state = ['style', 'align', 'font', 'initialize', 'character-mode', 'codepage', 'line-spacing', 'raw'];
+
+    return items.some((item) => !state.includes(item.type));
+  }
+
+  /**
      * Fetch the contents of line buffer
      *
      * @param  {options}   options   Options for flushing the buffer
@@ -229,7 +244,7 @@ class LineComposer {
     this.#buffer = [];
     this.#cursor = 0;
 
-    if (result.length === 0 && options.forceNewline) {
+    if (options.forceNewline && !LineComposer.hasContent(result)) {
       result.push({type: 'empty'});
     }
 

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -55,16 +55,17 @@ class LineComposer {
     const lines = TextWrap.wrap(value, {columns: this.#columns, width: this.style.width, indent: this.#cursor});
 
     for (let i = 0; i < lines.length; i++) {
-      if (lines[i].length) {
-        /* Add the line to the buffer */
-        this.add({type: 'text', value: lines[i], codepage}, lines[i].length * this.style.width);
+      /* Add the line to the buffer */
 
-        /* If it is not the last line, flush the buffer */
-        if (i < lines.length - 1) {
-          this.flush();
-        }
-      } else {
-        /* In case the line is empty, flush the buffer */
+      if (lines[i].length) {
+        this.add({type: 'text', value: lines[i], codepage}, lines[i].length * this.style.width);
+      }
+
+      /* A newline in the text ends the current line, even if it is empty. Text
+         after the last newline stays on the line, so that it can be continued
+         by the next call, and an empty text does nothing at all */
+
+      if (i < lines.length - 1) {
         this.flush({forceNewline: true});
       }
     }

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -82,7 +82,7 @@ class LineComposer {
    * @param {number} size Number of spaces to add to the line
    */
   space(size) {
-    this.add({type: 'space', size}, size);
+    this.add({type: 'space', size}, size * this.style.width);
   }
 
   /**
@@ -248,7 +248,7 @@ class LineComposer {
         }
 
         result = this.#merge([
-          {type: 'space', size: Math.max(0, this.#columns - this.#cursor)},
+          ...this.#padding(this.#columns - this.#cursor),
           ...before,
           ...items,
           ...after,
@@ -259,11 +259,11 @@ class LineComposer {
         const left = Math.max(0, this.#columns - this.#cursor) >> 1;
 
         result = this.#merge([
-          {type: 'space', size: left},
+          ...this.#padding(left),
           ...before,
           ...items,
           ...after,
-          {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor - left) : 0},
+          ...this.#padding(this.#embedded ? this.#columns - this.#cursor - left : 0),
         ]);
       }
 
@@ -272,7 +272,7 @@ class LineComposer {
           ...before,
           ...items,
           ...after,
-          {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor) : 0},
+          ...this.#padding(this.#embedded ? this.#columns - this.#cursor : 0),
         ]);
       }
     }
@@ -309,6 +309,43 @@ class LineComposer {
     if (result.length) {
       this.#callback(result);
     }
+  }
+
+  /**
+     * Padding for a number of columns, in single width spaces. Padding is
+     * printed in the default style of this composer, which is the style
+     * inherited by a table cell or box. When that style has double width,
+     * single width spaces need a temporary size change, otherwise an odd
+     * number of columns could not be filled.
+     *
+     * @param  {number}   columns   Number of columns to fill
+     * @return {array}              Array of items
+     */
+  #padding(columns) {
+    return LineComposer.padding(columns, this.style.getDefault('size'));
+  }
+
+  /**
+     * Padding for a number of columns, in single width spaces, see #padding()
+     *
+     * @param  {number}   columns   Number of columns to fill
+     * @param  {object}   size      The size in which the padding is printed, with a width and height
+     * @return {array}              Array of items
+     */
+  static padding(columns, size) {
+    if (columns <= 0) {
+      return [];
+    }
+
+    if (size.width === 1) {
+      return [{type: 'space', size: columns}];
+    }
+
+    return [
+      {type: 'style', property: 'size', value: {width: 1, height: size.height}},
+      {type: 'space', size: columns},
+      {type: 'style', property: 'size', value: {width: size.width, height: size.height}},
+    ];
   }
 
   /**

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -1,6 +1,16 @@
 import TextStyle from './text-style.js';
 import TextWrap from './text-wrap.js';
 
+/* Item types that only change the state of the printer and print nothing */
+
+const STATE_TYPES = [
+  'style', 'align', 'font', 'initialize', 'character-mode', 'codepage', 'line-spacing', 'motion-unit', 'raw',
+];
+
+/* Item types that print a block which advances the paper by itself */
+
+const BLOCK_TYPES = ['image', 'barcode', 'qrcode', 'pdf417'];
+
 /**
  * Compose lines of text and commands
  */
@@ -123,9 +133,20 @@ class LineComposer {
      * @return {boolean}            True if the line contains printable content
      */
   static hasContent(items) {
-    const state = ['style', 'align', 'font', 'initialize', 'character-mode', 'codepage', 'line-spacing', 'raw'];
+    return items.some((item) => !STATE_TYPES.includes(item.type));
+  }
 
-    return items.some((item) => !state.includes(item.type));
+  /**
+     * Determine if a line contains a block that advances the paper by itself,
+     * such as an image, barcode, QR code or PDF417 code, and nothing else
+     * that is printable
+     *
+     * @param  {object[]}   items   The items of a line
+     * @return {boolean}            True if the line is a self advancing block
+     */
+  static isBlock(items) {
+    return items.some((item) => BLOCK_TYPES.includes(item.type)) &&
+      items.every((item) => STATE_TYPES.includes(item.type) || BLOCK_TYPES.includes(item.type));
   }
 
   /**

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -211,7 +211,7 @@ class LineComposer {
         }
 
         result = this.#merge([
-          {type: 'space', size: this.#columns - this.#cursor},
+          {type: 'space', size: Math.max(0, this.#columns - this.#cursor)},
           ...this.#stored,
           ...buffer,
           ...store,
@@ -219,14 +219,14 @@ class LineComposer {
       }
 
       if (this.#align === 'center') {
-        const left = (this.#columns - this.#cursor) >> 1;
+        const left = Math.max(0, this.#columns - this.#cursor) >> 1;
 
         result = this.#merge([
           {type: 'space', size: left},
           ...this.#stored,
           ...buffer,
           ...store,
-          {type: 'space', size: this.#embedded ? this.#columns - this.#cursor - left : 0},
+          {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor - left) : 0},
         ]);
       }
 
@@ -235,7 +235,7 @@ class LineComposer {
           ...this.#stored,
           ...buffer,
           ...store,
-          {type: 'space', size: this.#embedded ? this.#columns - this.#cursor : 0},
+          {type: 'space', size: this.#embedded ? Math.max(0, this.#columns - this.#cursor) : 0},
         ]);
       }
     }

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -41,6 +41,7 @@ class LineComposer {
     this.#callback = options.callback || (() => {});
 
     this.style = new TextStyle({
+      defaults: options.style,
       callback: (value) => {
         this.add(value, 0);
       },

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -25,6 +25,7 @@ class LineComposer {
   #callback;
 
   #cursor = 0;
+  #trimmable = false;
   #stored;
   #buffer = [];
 
@@ -108,6 +109,7 @@ class LineComposer {
       }
 
       this.#cursor += length || 0;
+      this.#trimmable = false;
       return;
     }
 
@@ -119,6 +121,11 @@ class LineComposer {
 
     this.#cursor += length;
     this.#buffer = this.#buffer.concat(value);
+
+    /* Only a trailing space of text added with text() can be trimmed for right
+       alignment, the padding of table cells and boxes is part of the layout */
+
+    this.#trimmable = value.type === 'text';
   }
 
   /**
@@ -233,14 +240,9 @@ class LineComposer {
           }
         }
 
-        /* Remove trailing spaces from lines */
+        /* Remove a trailing space from text, so that it ends at the edge of the paper */
 
-        if (typeof last === 'number') {
-          if (buffer[last].type === 'space' && buffer[last].size > this.style.width) {
-            buffer[last].size -= this.style.width;
-            this.#cursor -= this.style.width;
-          }
-
+        if (typeof last === 'number' && this.#trimmable) {
           if (buffer[last].type === 'text' && buffer[last].value.endsWith(' ')) {
             buffer[last].value = buffer[last].value.slice(0, -1);
             this.#cursor -= this.style.width;
@@ -280,6 +282,7 @@ class LineComposer {
     this.#stored = restore;
     this.#buffer = [];
     this.#cursor = 0;
+    this.#trimmable = false;
 
     if (options.forceNewline && !LineComposer.hasContent(result)) {
       result.push({type: 'empty'});

--- a/src/line-composer.js
+++ b/src/line-composer.js
@@ -349,14 +349,16 @@ class LineComposer {
 
         result.push(item);
         last++;
-      } else if (item.type === 'style' && item.property === 'size') {
+      } else if (item.type === 'style') {
+        /* Consecutive changes of the same property collapse into the last one */
+
         const allowMerge =
           last >= 0 &&
           result[last].type === 'style' &&
-          result[last].property === 'size';
+          result[last].property === item.property;
 
         if (allowMerge) {
-          result[last].value = item.value;
+          result[last] = item;
           continue;
         }
 
@@ -366,6 +368,38 @@ class LineComposer {
         result.push(item);
         last++;
       }
+    }
+
+    return this.#dedupe(result);
+  }
+
+  /**
+     * Remove style commands that set a property to the value the printer
+     * already has. Every line starts in the default style.
+     *
+     * @param  {array}   items   Array of items
+     * @return {array}           Array of items without redundant style commands
+     */
+  #dedupe(items) {
+    const result = [];
+    const state = new Map();
+
+    const equal = (a, b) => (typeof a === 'object' && a !== null) ?
+      a.width === b.width && a.height === b.height :
+      a === b;
+
+    for (const item of items) {
+      if (item.type === 'style') {
+        const current = state.has(item.property) ? state.get(item.property) : this.style.getDefault(item.property);
+
+        if (equal(current, item.value)) {
+          continue;
+        }
+
+        state.set(item.property, item.value);
+      }
+
+      result.push(item);
     }
 
     return result;

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -306,9 +306,16 @@ class ReceiptPrinterEncoder {
       throw new Error('Initialize is not supported in table cells or boxes');
     }
 
+    /* The initialize command resets the printer, so it must be sent before any
+       alignment padding or pending styles of the current line */
+
+    this.#composer.flush();
+
     this.#composer.add(
         this.#language.initialize(),
     );
+
+    this.#composer.flush({forceFlush: true, ignoreAlignment: true});
 
     return this;
   }

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -1460,10 +1460,18 @@ class ReceiptPrinterEncoder {
     let result = [];
     let last = null;
 
-    for (const line of lines) {
-      for (const item of line) {
+    for (let i = 0; i < lines.length; i++) {
+      for (const item of lines[i]) {
         result.push(...item.payload);
         last = item;
+      }
+
+      /* Only feed the paper when the line contains printable content, a line
+         consisting of nothing but state changes, such as style, font or alignment
+         commands, would otherwise be printed as an empty line */
+
+      if (!LineComposer.hasContent(commands[i].commands)) {
+        continue;
       }
 
       if (this.#options.newline === '\n\r') {

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -657,7 +657,7 @@ class ReceiptPrinterEncoder {
 
       for (let c = 0; c < columns.length; c++) {
         const columnEncoder = new ReceiptPrinterEncoder(Object.assign({}, this.#options, {
-          width: columns[c].width,
+          width: columns[c].width * this.#composer.style.width,
           embedded: true,
           style: this.#inheritedStyle(),
         }));
@@ -695,7 +695,13 @@ class ReceiptPrinterEncoder {
             verticalAlign = columns[c].verticalAlign;
           }
 
-          const line = {commands: [{type: 'space', size: columns[c].width}], height: 1};
+          const line = {
+            commands: LineComposer.padding(
+                columns[c].width * this.#composer.style.width,
+                {width: this.#composer.style.width, height: this.#composer.style.height},
+            ),
+            height: 1,
+          };
 
           if (verticalAlign == 'bottom') {
             lines[c].unshift(line);
@@ -713,7 +719,7 @@ class ReceiptPrinterEncoder {
             this.#composer.space(columns[c].marginLeft);
           }
 
-          this.#composer.add(lines[c][l].commands, columns[c].width);
+          this.#composer.add(lines[c][l].commands, columns[c].width * this.#composer.style.width);
 
           if (typeof columns[c].marginRight !== 'undefined') {
             this.#composer.space(columns[c].marginRight);
@@ -729,8 +735,9 @@ class ReceiptPrinterEncoder {
 
   /**
      * Get the styles that embedded content, such as table cells and boxes,
-     * inherits from the current style. Width and height are not inherited,
-     * the column widths of a table are in characters of the current size.
+     * inherits from the current style. The widths of columns and boxes are
+     * in characters of the current size, so the embedded content is measured
+     * in columns of the paper.
      *
      * @return {object}   The inherited style properties
      */
@@ -740,6 +747,8 @@ class ReceiptPrinterEncoder {
       italic: this.#composer.style.italic,
       underline: this.#composer.style.underline,
       invert: this.#composer.style.invert,
+      width: this.#composer.style.width,
+      height: this.#composer.style.height,
     };
   }
 
@@ -792,7 +801,9 @@ class ReceiptPrinterEncoder {
       paddingRight: 0,
     }, options || {});
 
-    if (options.width + options.marginLeft + options.marginRight > this.#options.columns) {
+    const boxWidth = (options.width + options.marginLeft + options.marginRight) * this.#composer.style.width;
+
+    if (boxWidth > this.#options.columns) {
       throw new Error('Box is too wide');
     }
 
@@ -806,8 +817,10 @@ class ReceiptPrinterEncoder {
 
     /* Render the contents of the box */
 
+    const innerWidth = options.width - (options.style == 'none' ? 0 : 2) - options.paddingLeft - options.paddingRight;
+
     const columnEncoder = new ReceiptPrinterEncoder(Object.assign({}, this.#options, {
-      width: options.width - (options.style == 'none' ? 0 : 2) - options.paddingLeft - options.paddingRight,
+      width: innerWidth * this.#composer.style.width,
       embedded: true,
       style: this.#inheritedStyle(),
     }));
@@ -850,8 +863,7 @@ class ReceiptPrinterEncoder {
       }
 
       this.#composer.space(options.paddingLeft);
-      this.#composer.add(lines[i].commands,
-          options.width - (options.style == 'none' ? 0 : 2) - options.paddingLeft - options.paddingRight);
+      this.#composer.add(lines[i].commands, innerWidth * this.#composer.style.width);
       this.#composer.space(options.paddingRight);
 
       if (options.style != 'none') {

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -121,6 +121,8 @@ class ReceiptPrinterEncoder {
   #language;
   #composer;
 
+  #printerResolution = null;
+
   #printerCapabilities = {
     'fonts': {
       'A': {size: '12x24', columns: 42},
@@ -187,6 +189,7 @@ class ReceiptPrinterEncoder {
       }
 
       this.#printerCapabilities = printerDefinitions[options.printerModel].capabilities;
+      this.#printerResolution = printerDefinitions[options.printerModel].media?.dpi || null;
 
       /* Apply the printer definition to the defaults */
 
@@ -1193,7 +1196,7 @@ class ReceiptPrinterEncoder {
     /* Encode the image data */
 
     this.#composer.add(
-        this.#language.image(image, width, height, this.#options.imageMode),
+        this.#language.image(image, width, height, this.#options.imageMode, this.#printerResolution),
     );
 
     /* Reset alignment */

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -838,6 +838,10 @@ class ReceiptPrinterEncoder {
 
     const lines = columnEncoder.commands();
 
+    /* The vertical borders are as tall as the line, the current height is restored after them */
+
+    const height = this.#composer.style.height;
+
     /* Header */
 
     this.#composer.flush();
@@ -857,9 +861,9 @@ class ReceiptPrinterEncoder {
       this.#composer.space(options.marginLeft);
 
       if (options.style != 'none') {
-        this.#composer.style.height = lines[i].height;
+        this.#composer.style.height = Math.max(height, lines[i].height);
         this.#composer.text(elements[5], 'cp437');
-        this.#composer.style.height = 1;
+        this.#composer.style.height = height;
       }
 
       this.#composer.space(options.paddingLeft);
@@ -867,9 +871,9 @@ class ReceiptPrinterEncoder {
       this.#composer.space(options.paddingRight);
 
       if (options.style != 'none') {
-        this.#composer.style.height = lines[i].height;
+        this.#composer.style.height = Math.max(height, lines[i].height);
         this.#composer.text(elements[5], 'cp437');
-        this.#composer.style.height = 1;
+        this.#composer.style.height = height;
       }
 
       this.#composer.space(options.marginRight);

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -501,6 +501,7 @@ class ReceiptPrinterEncoder {
     return this;
   }
 
+  // eslint-disable-next-line valid-jsdoc
   /**
      * Change text size
      *
@@ -509,6 +510,7 @@ class ReceiptPrinterEncoder {
      * @param {number} [height]  The height of the text, 1 - 8
      * @return {ReceiptPrinterEncoder}
      */
+  // eslint-disable-next-line valid-jsdoc
   /**
      * @overload
      * @param {TextSize} value  The text size preset
@@ -608,6 +610,7 @@ class ReceiptPrinterEncoder {
     return this;
   }
 
+  // eslint-disable-next-line valid-jsdoc
   /**
      * Insert a table
      *
@@ -1393,6 +1396,7 @@ class ReceiptPrinterEncoder {
     return result;
   }
 
+  // eslint-disable-next-line valid-jsdoc
   /**
      * Encode all previous commands
      *
@@ -1400,16 +1404,19 @@ class ReceiptPrinterEncoder {
      * @param {'commands'} format
      * @return {{ commands: object[], height: number }[]}
      */
+  // eslint-disable-next-line valid-jsdoc
   /**
      * @overload
      * @param {'lines'} format
      * @return {object[][]}
      */
+  // eslint-disable-next-line valid-jsdoc
   /**
      * @overload
      * @param {string} [format]
      * @return {Uint8Array}
      */
+  // eslint-disable-next-line valid-jsdoc
   /**
      * @param {string} [format]  The format of the output, either 'commands',
      *                           'lines' or 'array', defaults to 'array'
@@ -1508,7 +1515,7 @@ class ReceiptPrinterEncoder {
   /**
    * Get the current column width
    *
-   * @returns {number}         The column width in characters
+   * @return {number}         The column width in characters
    */
   get columns() {
     return this.#composer.columns;

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -35,6 +35,7 @@ import printerDefinitions from '../generated/printers.js';
  * @property {Language} [language]
  * @property {'column' | 'raster'} [imageMode]
  * @property {number} [feedBeforeCut]
+ * @property {boolean} [feedAfterBlock]
  * @property {'\n\r' | '\n'} [newline]
  * @property {CodepageMappingName | Record<string, number>} [codepageMapping]
  * @property {Codepage[]} [codepageCandidates]
@@ -168,6 +169,7 @@ class ReceiptPrinterEncoder {
       language: 'esc-pos',
       imageMode: 'column',
       feedBeforeCut: 0,
+      feedAfterBlock: true,
       newline: '\n\r',
       codepageMapping: 'epson',
       codepageCandidates: null,
@@ -1490,6 +1492,13 @@ class ReceiptPrinterEncoder {
          commands, would otherwise be printed as an empty line */
 
       if (!LineComposer.hasContent(commands[i].commands)) {
+        continue;
+      }
+
+      /* Images, barcodes and QR codes advance the paper by themselves, the
+         line feed after them can be disabled with the feedAfterBlock option */
+
+      if (!this.#options.feedAfterBlock && LineComposer.isBlock(commands[i].commands)) {
         continue;
       }
 

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -630,6 +630,15 @@ class ReceiptPrinterEncoder {
      *
      */
   table(columns, data) {
+    /* Check if the table fits on the paper, taking margins and the current character width into account */
+
+    const width = columns.reduce((total, column) =>
+      total + column.width + (column.marginLeft || 0) + (column.marginRight || 0), 0);
+
+    if (width * this.#composer.style.width > this.#options.columns) {
+      throw new Error('Table is too wide');
+    }
+
     this.#composer.flush();
 
     /* Process all lines */

--- a/src/receipt-printer-encoder.js
+++ b/src/receipt-printer-encoder.js
@@ -283,6 +283,7 @@ class ReceiptPrinterEncoder {
       columns: this.#options.columns,
       align: 'left',
       size: 1,
+      style: this.#options.style,
 
       callback: (value) => this.#queue.push(value),
     });
@@ -658,6 +659,7 @@ class ReceiptPrinterEncoder {
         const columnEncoder = new ReceiptPrinterEncoder(Object.assign({}, this.#options, {
           width: columns[c].width,
           embedded: true,
+          style: this.#inheritedStyle(),
         }));
 
         columnEncoder.codepage(this.#codepage);
@@ -726,6 +728,22 @@ class ReceiptPrinterEncoder {
   }
 
   /**
+     * Get the styles that embedded content, such as table cells and boxes,
+     * inherits from the current style. Width and height are not inherited,
+     * the column widths of a table are in characters of the current size.
+     *
+     * @return {object}   The inherited style properties
+     */
+  #inheritedStyle() {
+    return {
+      bold: this.#composer.style.bold,
+      italic: this.#composer.style.italic,
+      underline: this.#composer.style.underline,
+      invert: this.#composer.style.invert,
+    };
+  }
+
+  /**
      * Insert a horizontal rule
      *
      * @param  {RuleOptions}     [options]  And object with the following properties:
@@ -791,6 +809,7 @@ class ReceiptPrinterEncoder {
     const columnEncoder = new ReceiptPrinterEncoder(Object.assign({}, this.#options, {
       width: options.width - (options.style == 'none' ? 0 : 2) - options.paddingLeft - options.paddingRight,
       embedded: true,
+      style: this.#inheritedStyle(),
     }));
 
     columnEncoder.codepage(this.#codepage);

--- a/src/text-style.js
+++ b/src/text-style.js
@@ -26,6 +26,20 @@ class TextStyle {
   }
 
   /**
+     * Get the default value of a style property
+     *
+     * @param  {string}   property   The property, 'size' for the combined width and height
+     * @return {boolean|object}      The default value
+     */
+  getDefault(property) {
+    if (property === 'size') {
+      return {width: this.#default.width, height: this.#default.height};
+    }
+
+    return this.#default[property];
+  }
+
+  /**
      * Return commands to get to the default style from the current style
      *
      * @return {array}   Array of modified properties

--- a/src/text-style.js
+++ b/src/text-style.js
@@ -19,8 +19,13 @@ class TextStyle {
      * Create a new TextStyle object
      *
      * @param  {object}   options   Object containing configuration options
+     *                              - callback: called with every style change
+     *                              - defaults: style properties that override the defaults
      */
   constructor(options) {
+    /* The defaults can be overridden, for example by a table cell that inherits the style of the table */
+
+    this.#default = Object.assign({}, this.#default, options.defaults || {});
     this.#current = structuredClone(this.#default);
     this.#callback = options.callback || (() => {});
   }

--- a/src/text-wrap.js
+++ b/src/text-wrap.js
@@ -1,6 +1,17 @@
-
 /**
  * Wrap text into lines of a specified width.
+ *
+ * Whitespace is handled by the following rules:
+ *
+ * - Whitespace between two words is a separator. When the second word fits on
+ *   the line, the separator is printed. When the second word wraps, the
+ *   separator becomes the newline and is not printed.
+ * - Whitespace before the first word of a line is literal and printed as
+ *   indentation, unless the line continues an existing line on the printer,
+ *   in which case it is a separator between the existing content and the word.
+ * - Whitespace after the last word of a line is literal and printed.
+ * - Literal whitespace never causes a wrap, it is clipped at the edge of the line.
+ * - Non-breaking spaces are part of words.
  */
 class TextWrap {
   /**
@@ -12,104 +23,138 @@ class TextWrap {
      */
   static wrap(value, options) {
     const result = [];
-    let line = [];
-    let length = options.indent || 0;
     const width = options.width || 1;
     const columns = options.columns || 42;
+    const indent = options.indent || 0;
 
     const lines = String(value).split(/\r\n|\n/g);
 
-    for (const value of lines) {
-      const chunks = value.match(/[^\s-]+?-\b|\S+|\s+|\r\n?|\n/g) || ['~~empty~~'];
+    for (let l = 0; l < lines.length; l++) {
+      let line = [];
 
-      for (const chunk of chunks) {
-        if (chunk === '~~empty~~') {
-          result.push(line);
-          line = [];
-          length = 0;
+      /* Only the first line can continue an existing line on the printer */
+
+      let length = l === 0 ? indent : 0;
+
+      /* Whitespace that is waiting for the next word, to decide if it is printed */
+
+      let separator = null;
+
+      /* Split the line into words and whitespace, a non-breaking space is part of a word */
+
+      const tokens = lines[l].match(/[^ \t\f\v-]+?-\b|[^ \t\f\v]+|[ \t\f\v]+/g) || [];
+
+      /* Add literal whitespace to the line, clipped at the edge of the line */
+
+      const literal = (whitespace) => {
+        const fit = Math.floor((columns - length) / width);
+
+        if (fit > 0) {
+          line.push(whitespace.slice(0, fit));
+          length += Math.min(fit, whitespace.length) * width;
+        }
+      };
+
+      for (const token of tokens) {
+        /* Whitespace */
+
+        if (/^[ \t\f\v]+$/.test(token)) {
+          if (line.length === 0 && length === 0) {
+            literal(token);
+          } else {
+            separator = token;
+          }
+
           continue;
         }
 
-        /* The word does not fit on the line */
+        /* The word fits on the line, including the separator before it */
 
-        if (length + (chunk.length * width) > columns) {
-          /* The word is longer than the line */
+        const separatorLength = separator ? separator.length * width : 0;
 
-          if (chunk.length * width > columns) {
-            /* Calculate the remaining space on the line */
+        if (length + separatorLength + (token.length * width) <= columns) {
+          if (separator) {
+            line.push(separator);
+            length += separatorLength;
+            separator = null;
+          }
 
-            const remaining = columns - length;
+          line.push(token);
+          length += token.length * width;
 
-            /* Split the word into pieces */
+          continue;
+        }
 
-            const letters = chunk.split('');
-            let piece;
-            const pieces = [];
+        /* The word is longer than the line */
 
-            /* If there are at least 8 position remaining, break early  */
+        if (token.length * width > columns) {
+          const letters = token.split('');
+          let piece;
+          const pieces = [];
 
-            if (remaining > 8 * width) {
-              piece = letters.splice(0, Math.floor(remaining / width)).join('');
+          /* If there are at least 8 positions remaining, break early */
 
-              line.push(piece);
+          const remaining = columns - length - separatorLength;
+
+          if (remaining > 8 * width) {
+            if (separator) {
+              line.push(separator);
+              length += separatorLength;
+            }
+
+            piece = letters.splice(0, Math.floor(remaining / width)).join('');
+
+            line.push(piece);
+            result.push(line);
+
+            line = [];
+            length = 0;
+          }
+
+          separator = null;
+
+          /* The remaining letters can be split into pieces the size of the width */
+
+          while ((piece = letters.splice(0, Math.floor(columns / width))).length) {
+            pieces.push(piece.join(''));
+          }
+
+          for (const piece of pieces) {
+            if (length + (piece.length * width) > columns) {
               result.push(line);
-
               line = [];
               length = 0;
             }
 
-            /* The remaining letters can be split into pieces the size of the width */
-
-            while ((piece = letters.splice(0, Math.floor(columns / width))).length) {
-              pieces.push(piece.join(''));
-            }
-
-            for (const piece of pieces) {
-              if (length + (piece.length * width) > columns) {
-                result.push(line);
-                line = [];
-                length = 0;
-              }
-
-              line.push(piece);
-              length += piece.length * width;
-            }
-
-            continue;
+            line.push(piece);
+            length += piece.length * width;
           }
 
-          /* Word fits on the next line */
-          result.push(line);
-          line = [];
-          length = 0;
-        }
-
-        /* Check if we are whitespace */
-
-        if (chunk.match(/\s+/) && length == 0) {
           continue;
         }
 
-        line.push(chunk);
-        length += chunk.length * width;
-      }
+        /* The word fits on the next line, the separator becomes the newline */
 
-      if (line.length > 0) {
+        separator = null;
+
         result.push(line);
         line = [];
         length = 0;
+
+        line.push(token);
+        length += token.length * width;
       }
+
+      /* Whitespace after the last word is literal */
+
+      if (separator) {
+        literal(separator);
+      }
+
+      result.push(line);
     }
 
-    for (let i = 0; i < result.length; i++) {
-      result[i] = result[i].join('');
-
-      if (i < result.length - 1) {
-        result[i] = result[i].trimEnd();
-      }
-    }
-
-    return result;
+    return result.map((line) => line.join(''));
   }
 }
 

--- a/test/alignment.js
+++ b/test/alignment.js
@@ -43,7 +43,7 @@ describe('Alignment on the first line', function() {
         let result = encoder.initialize().align('center').bold(true).line('hello').encode();
 
         it('should send the initialize command before the alignment spaces and styles', function () {
-            assert.deepEqual(new Uint8Array([ ...INIT, ...spaces(18), 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, 27, 69, 1, 27, 69, 0 ]), result);
+            assert.deepEqual(new Uint8Array([ ...INIT, ...spaces(18), 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL ]), result);
         });
     });
 

--- a/test/alignment.js
+++ b/test/alignment.js
@@ -1,0 +1,76 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* The initialize command resets the printer, so it must not be sent after the
+   spaces used for alignment, see #57 */
+
+describe('Alignment on the first line', function() {
+    const INIT = [ 27, 64, 28, 46, 27, 77, 0 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const HELLO = [ 104, 101, 108, 108, 111 ];
+    const NL = [ 10, 13 ];
+    const spaces = (n) => new Array(n).fill(32);
+
+    describe('initialize().align(center).line(hello)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().align('center').line('hello').encode();
+
+        it('should send the initialize command before the alignment spaces', function () {
+            assert.deepEqual(new Uint8Array([ ...INIT, ...CODEPAGE, ...spaces(18), ...HELLO, ...NL ]), result);
+        });
+    });
+
+    describe('initialize().align(right).line(hello)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().align('right').line('hello').encode();
+
+        it('should send the initialize command before the alignment spaces', function () {
+            assert.deepEqual(new Uint8Array([ ...INIT, ...CODEPAGE, ...spaces(37), ...HELLO, ...NL ]), result);
+        });
+    });
+
+    describe('initialize().align(center).line(hello).align(right).line(again)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().align('center').line('hello').align('right').line('again').encode();
+
+        it('should align both lines, as in the report', function () {
+            assert.deepEqual(new Uint8Array([ ...INIT, ...CODEPAGE, ...spaces(18), ...HELLO, ...NL, ...spaces(37), 97, 103, 97, 105, 110, ...NL ]), result);
+        });
+    });
+
+    describe('initialize().align(center).bold(true).line(hello)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().align('center').bold(true).line('hello').encode();
+
+        it('should send the initialize command before the alignment spaces and styles', function () {
+            assert.deepEqual(new Uint8Array([ ...INIT, ...spaces(18), 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, 27, 69, 1, 27, 69, 0 ]), result);
+        });
+    });
+
+    describe('initialize().line(hello)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().line('hello').encode();
+
+        it('should produce the same bytes as before, without a line feed after initialize', function () {
+            assert.deepEqual(new Uint8Array([ ...INIT, ...CODEPAGE, ...HELLO, ...NL ]), result);
+        });
+    });
+
+    describe('text(a).initialize().line(b)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.text('a').initialize().line('b').encode();
+
+        it('should print pending text before the initialize command', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, ...INIT, 98, ...NL ]), result);
+        });
+    });
+
+    describe('initialize().align(center).line(hello) on star-prnt', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
+        let result = encoder.initialize().align('center').line('hello').encode();
+
+        it('should send the initialize command before the alignment spaces', function () {
+            assert.deepEqual(new Uint8Array([ 27, 64, 24, 27, 29, 116, 0, ...spaces(21), ...HELLO, ...NL ]), result);
+        });
+    });
+});

--- a/test/blank-lines.js
+++ b/test/blank-lines.js
@@ -99,6 +99,24 @@ describe('Blank lines caused by state-only lines', function() {
         });
     });
 
+    describe('initialize().codepage(cp437).pulse()', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.initialize().codepage('cp437').pulse().encode();
+
+        it('should not feed the paper when opening the drawer', function () {
+            assert.deepEqual(new Uint8Array([ 27, 64, 28, 46, 27, 77, 0, 27, 112, 0, 50, 250 ]), result);
+        });
+    });
+
+    describe('initialize().codepage(star/standard).pulse() on star-prnt', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt' });
+        let result = encoder.initialize().codepage('star/standard').pulse().encode();
+
+        it('should not feed the paper when opening the drawer', function () {
+            assert.deepEqual(new Uint8Array([ 27, 64, 24, 27, 7, 20, 20, 7 ]), result);
+        });
+    });
+
     describe('line(hello).newline().line(hello)', function () {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.line('hello').newline().line('hello').encode();

--- a/test/blank-lines.js
+++ b/test/blank-lines.js
@@ -1,0 +1,128 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import ImageData from '@canvas/image-data';
+import { assert } from 'chai';
+
+/* Lines that only change the state of the printer, such as style, font,
+   alignment or raw commands, should not feed the paper, see #63 */
+
+describe('Blank lines caused by state-only lines', function() {
+    const image = new ImageData(8, 8);
+    image.data.fill(255);
+
+    const CODEPAGE = [ 27, 116, 0 ];
+    const HELLO = [ ...CODEPAGE, 104, 101, 108, 108, 111 ];
+    const IMAGE = [ 29, 118, 48, 0, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+    const CUT = [ 29, 86, 0 ];
+    const BOLD_ON = [ 27, 69, 1 ];
+    const BOLD_OFF = [ 27, 69, 0 ];
+    const NL = [ 10, 13 ];
+
+    describe('bold(true).line(hello).bold(false).image(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.bold(true).line('hello').bold(false).image(image, 8, 8).encode();
+
+        it('should not have an empty line between the text and the image', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...IMAGE, ...NL ]), result);
+        });
+    });
+
+    describe('bold(true).line(hello).image(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.bold(true).line('hello').image(image, 8, 8).encode();
+
+        it('should not have empty lines before the image or at the end', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...BOLD_ON, ...IMAGE, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+        });
+    });
+
+    describe('size(2).line(hello).size(1).qrcode(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.size(2).line('hello').size(1).qrcode('x').encode();
+
+        it('should not have an empty line between the text and the qr code', function () {
+            let feeds = Array.from(result).filter((b) => b === 10).length;
+            assert.equal(feeds, 2);
+        });
+    });
+
+    describe('bold(true).line(hello).cut()', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.bold(true).line('hello').cut().encode();
+
+        it('should not have an empty line before the cut', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...BOLD_ON, ...CUT, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+        });
+    });
+
+    describe('line(hello).bold(true)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.line('hello').bold(true).encode();
+
+        it('should not have an empty line at the end', function () {
+            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+        });
+    });
+
+    describe('line(hello).font(B).image(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.line('hello').font('B').image(image, 8, 8).encode();
+
+        it('should not have an empty line between the text and the image', function () {
+            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL, 27, 77, 1, ...IMAGE, ...NL ]), result);
+        });
+    });
+
+    describe('initialize().image(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.initialize().image(image, 8, 8).encode();
+
+        it('should not have an empty line before the image', function () {
+            assert.deepEqual(new Uint8Array([ 27, 64, 28, 46, 27, 77, 0, ...IMAGE, ...NL ]), result);
+        });
+    });
+
+    describe('line(hello).raw(...).image(...)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.line('hello').raw([ 27, 97, 1 ]).image(image, 8, 8).encode();
+
+        it('should not have an empty line after the raw command', function () {
+            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL, 27, 97, 1, ...IMAGE, ...NL ]), result);
+        });
+    });
+
+    describe('raw(...).newline()', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.raw([ 104, 105 ]).newline().encode();
+
+        it('should feed when the user adds the newline', function () {
+            assert.deepEqual(new Uint8Array([ 104, 105, ...NL ]), result);
+        });
+    });
+
+    describe('line(hello).newline().line(hello)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.line('hello').newline().line('hello').encode();
+
+        it('should still have an explicit empty line', function () {
+            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL, ...NL, 104, 101, 108, 108, 111, ...NL ]), result);
+        });
+    });
+
+    describe('bold(true).newline().bold(false)', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.bold(true).newline().bold(false).encode();
+
+        it('should still feed for an explicit newline', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+        });
+    });
+
+    describe('bold(true).line(hello).bold(false) on star-prnt', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
+        let result = encoder.bold(true).line('hello').bold(false).encode();
+
+        it('should not have an empty line at the end', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 70, ...NL, 27, 69, 27, 70 ]), result);
+        });
+    });
+});

--- a/test/blank-lines.js
+++ b/test/blank-lines.js
@@ -22,7 +22,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.bold(true).line('hello').bold(false).image(image, 8, 8).encode();
 
         it('should not have an empty line between the text and the image', function () {
-            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...IMAGE, ...NL ]), result);
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...IMAGE, ...NL ]), result);
         });
     });
 
@@ -31,7 +31,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.bold(true).line('hello').image(image, 8, 8).encode();
 
         it('should not have empty lines before the image or at the end', function () {
-            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...BOLD_ON, ...IMAGE, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...IMAGE, ...NL ]), result);
         });
     });
 
@@ -50,7 +50,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.bold(true).line('hello').cut().encode();
 
         it('should not have an empty line before the cut', function () {
-            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF, ...BOLD_ON, ...CUT, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...HELLO, ...BOLD_OFF, ...NL, ...CUT, ...NL ]), result);
         });
     });
 
@@ -59,7 +59,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.line('hello').bold(true).encode();
 
         it('should not have an empty line at the end', function () {
-            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+            assert.deepEqual(new Uint8Array([ ...HELLO, ...NL ]), result);
         });
     });
 
@@ -131,7 +131,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.bold(true).newline().bold(false).encode();
 
         it('should still feed for an explicit newline', function () {
-            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...BOLD_OFF, ...NL, ...BOLD_ON, ...BOLD_OFF ]), result);
+            assert.deepEqual(new Uint8Array([ ...NL ]), result);
         });
     });
 
@@ -140,7 +140,7 @@ describe('Blank lines caused by state-only lines', function() {
         let result = encoder.bold(true).line('hello').bold(false).encode();
 
         it('should not have an empty line at the end', function () {
-            assert.deepEqual(new Uint8Array([ 27, 69, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 70, ...NL, 27, 69, 27, 70 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 70, ...NL ]), result);
         });
     });
 });

--- a/test/feed-after-block.js
+++ b/test/feed-after-block.js
@@ -1,0 +1,118 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import ImageData from '@canvas/image-data';
+import { assert } from 'chai';
+
+/* Images, barcodes and QR codes advance the paper by themselves. The line feed
+   that follows them can be disabled with the feedAfterBlock option, see #43 */
+
+describe('feedAfterBlock', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const IMAGE = [ 29, 118, 48, 0, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
+    const STRIP = [ 27, 42, 33, 8, 0, ...new Array(24).fill(0), 10 ];
+    const QRCODE = [ 29, 40, 107, 4, 0, 49, 65, 50, 0, 29, 40, 107, 3, 0, 49, 67, 6, 29, 40, 107, 3, 0, 49, 69, 49, 29, 40, 107, 4, 0, 49, 80, 48, 120, 29, 40, 107, 3, 0, 49, 81, 48 ];
+    const BARCODE = [ 29, 104, 60, 29, 119, 3, 29, 72, 0, 29, 107, 73, 9, 123, 66, 67, 79, 68, 69, 49, 50, 56 ];
+
+    const image = new ImageData(8, 8);
+    image.data.fill(255);
+
+    describe('image() with the default', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' });
+        let result = encoder.image(image, 8, 8).encode();
+
+        it('should still feed after the image', function () {
+            assert.deepEqual(new Uint8Array([ ...IMAGE, ...NL ]), result);
+        });
+    });
+
+    describe('image() in raster mode with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster', feedAfterBlock: false });
+        let result = encoder.image(image, 8, 8).encode();
+
+        it('should not feed after the image', function () {
+            assert.deepEqual(new Uint8Array([ ...IMAGE ]), result);
+        });
+    });
+
+    describe('image() in column mode with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'column', feedAfterBlock: false });
+        let result = encoder.image(image, 8, 8).encode();
+
+        it('should keep the line feed of the strip, but not feed after the image', function () {
+            assert.deepEqual(new Uint8Array([ 27, 51, 24, ...STRIP, 27, 50 ]), result);
+        });
+    });
+
+    describe('image().line(hello) with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster', feedAfterBlock: false });
+        let result = encoder.image(image, 8, 8).line('hello').encode();
+
+        it('should print the text directly below the image', function () {
+            assert.deepEqual(new Uint8Array([ ...IMAGE, ...CODEPAGE, 104, 101, 108, 108, 111, ...NL ]), result);
+        });
+    });
+
+    describe('align(center).image().line(hello) with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster', feedAfterBlock: false });
+        let result = encoder.align('center').image(image, 8, 8).line('hello').encode();
+
+        it('should not feed after the image, even with alignment commands around it', function () {
+            assert.deepEqual(new Uint8Array([ 27, 97, 1, ...IMAGE, 27, 97, 0, ...CODEPAGE, ...new Array(18).fill(32), 104, 101, 108, 108, 111, ...NL ]), result);
+        });
+    });
+
+    describe('image().newline().line(hello) with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster', feedAfterBlock: false });
+        let result = encoder.image(image, 8, 8).newline().line('hello').encode();
+
+        it('should feed when the user adds a newline', function () {
+            assert.deepEqual(new Uint8Array([ ...IMAGE, ...NL, ...CODEPAGE, 104, 101, 108, 108, 111, ...NL ]), result);
+        });
+    });
+
+    describe('qrcode(x) with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', feedAfterBlock: false });
+        let result = encoder.qrcode('x').encode();
+
+        it('should not feed after the qr code', function () {
+            assert.deepEqual(new Uint8Array([ ...QRCODE ]), result);
+        });
+    });
+
+    describe('barcode(CODE128, code128, 60) with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', feedAfterBlock: false });
+        let result = encoder.barcode('CODE128', 'code128', 60).encode();
+
+        it('should not feed after the barcode', function () {
+            assert.deepEqual(new Uint8Array([ ...BARCODE ]), result);
+        });
+    });
+
+    describe('pdf417(x) with feedAfterBlock false', function () {
+        let withFeed = new ReceiptPrinterEncoder({ language: 'esc-pos' }).pdf417('x').encode();
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos', feedAfterBlock: false }).pdf417('x').encode();
+
+        it('should not feed after the pdf417 code', function () {
+            assert.deepEqual(new Uint8Array([ 10, 13 ]), withFeed.slice(-2));
+            assert.deepEqual(new Uint8Array(withFeed.slice(0, -2)), result);
+        });
+    });
+
+    describe('line(hello).cut() with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', feedAfterBlock: false });
+        let result = encoder.line('hello').cut().encode();
+
+        it('should not affect text lines or cuts', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 104, 101, 108, 108, 111, ...NL, 29, 86, 0, ...NL ]), result);
+        });
+    });
+
+    describe('image() on star-prnt with feedAfterBlock false', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false, feedAfterBlock: false });
+        let result = encoder.image(image, 8, 24).encode();
+
+        it('should not feed after the image', function () {
+            assert.deepEqual(new Uint8Array([ 27, 48, 27, 88, 8, 0, ...new Array(24).fill(0), 10, 13, 27, 122, 1 ]), result);
+        });
+    });
+});

--- a/test/image.js
+++ b/test/image.js
@@ -1,0 +1,72 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import ImageData from '@canvas/image-data';
+import { assert } from 'chai';
+
+/* Column mode images are printed in strips of 24 dots. The line spacing between
+   the strips is set in motion units, which are half a dot on Epson printers and
+   one dot on many others. When the resolution of the printer is known, the
+   motion unit is set to one dot explicitly, see #47 */
+
+describe('Column mode images', function() {
+    const LINE_SPACING_24 = [ 27, 51, 24 ];
+    const LINE_SPACING_DEFAULT = [ 27, 50 ];
+    const MOTION_UNIT = (dpi) => [ 29, 80, dpi, dpi ];
+    const MOTION_UNIT_DEFAULT = [ 29, 80, 0, 0 ];
+    const STRIP = [ 27, 42, 33, 8, 0, ...new Array(24).fill(0), 10 ];
+    const NL = [ 10, 13 ];
+
+    const image = (height) => {
+        const data = new ImageData(8, height);
+        data.data.fill(255);
+        return data;
+    };
+
+    describe('image(8 x 48) without a printer model', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'column' });
+        let result = encoder.image(image(48), 8, 48).encode();
+
+        it('should use 24 units of line spacing for two strips, without changing the motion unit', function () {
+            assert.deepEqual(new Uint8Array([ ...LINE_SPACING_24, ...STRIP, ...STRIP, ...LINE_SPACING_DEFAULT, ...NL ]), result);
+        });
+    });
+
+    describe('image(8 x 8) without a printer model', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'column' });
+        let result = encoder.image(image(8), 8, 8).encode();
+
+        it('should pad a partial strip to 24 dots', function () {
+            assert.deepEqual(new Uint8Array([ ...LINE_SPACING_24, ...STRIP, ...LINE_SPACING_DEFAULT, ...NL ]), result);
+        });
+    });
+
+    describe('image(8 x 48) on an Epson TM-T88V, 180 dpi', function () {
+        let encoder = new ReceiptPrinterEncoder({ printerModel: 'epson-tm-t88v', imageMode: 'column' });
+        let result = encoder.image(image(48), 8, 48).encode();
+
+        it('should set the motion unit to one dot around the image and restore it', function () {
+            assert.deepEqual(new Uint8Array([
+                ...MOTION_UNIT(180), ...LINE_SPACING_24, ...STRIP, ...STRIP, ...LINE_SPACING_DEFAULT, ...MOTION_UNIT_DEFAULT, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('image(8 x 24) on an Xprinter XP-T80Q, 203 dpi', function () {
+        let encoder = new ReceiptPrinterEncoder({ printerModel: 'xprinter-xp-t80q', imageMode: 'column' });
+        let result = encoder.image(image(24), 8, 24).encode();
+
+        it('should use the resolution of the printer as the motion unit', function () {
+            assert.deepEqual(new Uint8Array([
+                ...MOTION_UNIT(203), ...LINE_SPACING_24, ...STRIP, ...LINE_SPACING_DEFAULT, ...MOTION_UNIT_DEFAULT, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('image(8 x 8) on an Epson TM-T70, raster mode by profile', function () {
+        let encoder = new ReceiptPrinterEncoder({ printerModel: 'epson-tm-t70' });
+        let result = encoder.image(image(8), 8, 8).encode();
+
+        it('should not touch the motion unit in raster mode', function () {
+            assert.deepEqual(new Uint8Array([ 29, 118, 48, 0, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...NL ]), result);
+        });
+    });
+});

--- a/test/language-esc-pos.js
+++ b/test/language-esc-pos.js
@@ -262,8 +262,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', createCanvas });
         let result = encoder.image(canvas, 8, 8).encode();
                 
-        it('should be [ 27, 51, 36, 27, 42, 33, 8, 0, 128, 0, 0, 0, 0, ... ]', function () {
-            assert.deepEqual(new Uint8Array([27, 51, 36, 27, 42, 33, 8, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 27, 50, 10, 13]), result);
+        it('should be [ 27, 51, 24, 27, 42, 33, 8, 0, 128, 0, 0, 0, 0, ... ]', function () {
+            assert.deepEqual(new Uint8Array([27, 51, 24, 27, 42, 33, 8, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 27, 50, 10, 13]), result);
         });
     });
 

--- a/test/language-esc-pos.js
+++ b/test/language-esc-pos.js
@@ -8,8 +8,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.text('hello').encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -17,8 +17,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.text('hello').newline().encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -26,8 +26,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.text('hello').newline().newline().encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13 ]), result);
         });
     });
 
@@ -35,8 +35,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.text('hello').newline(4).encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]), result);
         });
     });
 
@@ -44,8 +44,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.line('hello').encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -53,8 +53,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.text('héllo').encode();
         
-        it('should be [ 104, 63, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 130, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 130, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 130, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -71,8 +71,8 @@ describe('LanguageEscPos', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
         let result = encoder.codepage('cp437').text('héllo').encode();
         
-        it('should be [ 104, 130, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 130, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 116, 0, 104, 130, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 130, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -100,7 +100,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.bold(true).text('hello').bold(false).encode();
         
         it('should be [ 27, 69, 1, ..., 27, 69, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 69, 1, 104, 101, 108, 108, 111, 27, 69, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, 27, 116, 0, 104, 101, 108, 108, 111, 27, 69, 0, 10, 13 ]), result);
         });
     });
 
@@ -109,7 +109,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.bold().text('hello').bold().encode();
         
         it('should be [ 27, 69, 1, ..., 27, 69, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 69, 1, 104, 101, 108, 108, 111, 27, 69, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, 27, 116, 0, 104, 101, 108, 108, 111, 27, 69, 0, 10, 13 ]), result);
         });
     });
 
@@ -118,7 +118,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.italic().text('hello').italic().encode();
         
         it('should be [ 27, 69, 1, ..., 27, 69, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 52, 1, 104, 101, 108, 108, 111, 27, 52, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 52, 1, 27, 116, 0, 104, 101, 108, 108, 111, 27, 52, 0, 10, 13 ]), result);
         });
     });
 
@@ -127,7 +127,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.underline(true).text('hello').underline(false).encode();
         
         it('should be [ 27, 45, 1, ..., 27, 45, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 45, 1, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 45, 1, 27, 116, 0, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
         });
     });
 
@@ -136,7 +136,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.underline().text('hello').underline().encode();
         
         it('should be [ 27, 45, 1, ..., 27, 45, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 45, 1, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 45, 1, 27, 116, 0, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
         });
     });
 
@@ -145,7 +145,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.invert().text('hello').invert().encode();
         
         it('should be [ 29, 66, 1, ..., 29, 66, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 29, 66, 1, 104, 101, 108, 108, 111, 29, 66, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 29, 66, 1, 27, 116, 0, 104, 101, 108, 108, 111, 29, 66, 0, 10, 13 ]), result);
         });
     });
 
@@ -154,7 +154,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.width(2).text('hello').width(1).encode();
         
         it('should be [ 29, 33, 16, ..., 29, 33, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 29, 33, 16, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 29, 33, 16, 27, 116, 0, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
         });
     });
 
@@ -163,7 +163,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.height(2).text('hello').height(1).encode();
         
         it('should be [ 29, 33, 1, ..., 29, 33, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 29, 33, 1, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 29, 33, 1, 27, 116, 0, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
         });
     });
 
@@ -172,7 +172,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.width(2).height(2).text('hello').width(1).height(1).encode();
         
         it('should be [ 29, 33, 17, ..., 29, 33, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 29, 33, 17, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 29, 33, 17, 27, 116, 0, 104, 101, 108, 108, 111, 29, 33, 0, 10, 13 ]), result);
         });
     });
 
@@ -181,7 +181,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.align('left').line('hello').encode();
         
         it('should be [ ..., 32, 32, 32, 32, 32, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 32, 32, 32, 32, 32, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 104, 101, 108, 108, 111, 32, 32, 32, 32, 32, 10, 13 ]), result);
         });
     });
 
@@ -190,7 +190,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.align('center').line('hello').encode();
         
         it('should be [ 32, 32, ..., 32, 32, 32, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 32, 32, 104, 101, 108, 108, 111, 32, 32, 32, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 32, 32, 104, 101, 108, 108, 111, 32, 32, 32, 10, 13 ]), result);
         });
     });
 
@@ -199,7 +199,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.align('right').line('hello').encode();
         
         it('should be [ 32, 32, 32, 32, 32, ..., 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 32, 32, 32, 32, 32, 104, 101, 108, 108, 111, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 116, 0, 32, 32, 32, 32, 32, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 

--- a/test/language-esc-pos.js
+++ b/test/language-esc-pos.js
@@ -308,7 +308,7 @@ describe('LanguageEscPos', function() {
         let result = encoder.raw([ 0x1c, 0x2e ]).encode();
         
         it('should be [ 28, 46 ]', function () {
-            assert.deepEqual(new Uint8Array([ 28, 46, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 28, 46 ]), result);
         });
     });
 

--- a/test/language-star-prnt.js
+++ b/test/language-star-prnt.js
@@ -266,8 +266,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.raw([ 0x1c, 0x2e ]).encode();
         
-        it('should be [ 28, 46, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 28, 46, 10, 13 ]), result);
+        it('should be [ 28, 46 ]', function () {
+            assert.deepEqual(new Uint8Array([ 28, 46 ]), result);
         });
     });
 

--- a/test/language-star-prnt.js
+++ b/test/language-star-prnt.js
@@ -8,8 +8,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.text('hello').encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -17,8 +17,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.text('hello').newline().encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -26,8 +26,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.text('hello').newline().newline().encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13 ]), result);
         });
     });
 
@@ -35,8 +35,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.text('hello').newline(4).encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13, 10, 13, 10, 13, 10, 13 ]), result);
         });
     });
 
@@ -44,8 +44,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.line('hello').encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -53,8 +53,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.text('héllo').encode();
         
-        it('should be [ 104, 176, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 176, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 176, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 176, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -109,7 +109,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.bold(true).text('hello').bold(false).encode();
         
         it('should be [ 27, 69, ..., 27, 70, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 69, 104, 101, 108, 108, 111, 27, 70, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 70, 10, 13 ]), result);
         });
     });
 
@@ -118,7 +118,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.bold().text('hello').bold().encode();
         
         it('should be [ 27, 69, ..., 27, 70, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 69, 104, 101, 108, 108, 111, 27, 70, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 70, 10, 13 ]), result);
         });
     });
 
@@ -126,8 +126,8 @@ describe('LanguageStarPrnt', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'star-prnt', autoFlush: false });
         let result = encoder.italic().text('hello').italic().encode();
         
-        it('should be [ 104, 101, 108, 108, 111, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 104, 101, 108, 108, 111, 10, 13 ]), result);
+        it('should be [ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]', function () {
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 
@@ -136,7 +136,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.underline(true).text('hello').underline(false).encode();
         
         it('should be [ 27, 45, 1, ..., 27, 45, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 45, 1, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 45, 1, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
         });
     });
 
@@ -145,7 +145,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.underline().text('hello').underline().encode();
         
         it('should be [ 27, 45, 1, ..., 27, 45, 0, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([ 27, 45, 1, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 45, 1, 27, 29, 116, 0, 104, 101, 108, 108, 111, 27, 45, 0, 10, 13 ]), result);
         });
     });
 
@@ -154,7 +154,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.align('left').line('hello').encode();
         
         it('should be [ ..., 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([104, 101, 108, 108, 111, 32, 32, 32, 32, 32, 10, 13]), result);
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 104, 101, 108, 108, 111, 32, 32, 32, 32, 32, 10, 13 ]), result);
         });
     });
 
@@ -163,7 +163,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.align('center').line('hello').encode();
         
         it('should be [ 32, 32, ..., 32, 32, 32, 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([32, 32, 104, 101, 108, 108, 111, 32, 32, 32, 10, 13]), result);
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 32, 32, 104, 101, 108, 108, 111, 32, 32, 32, 10, 13 ]), result);
         });
     });
 
@@ -172,7 +172,7 @@ describe('LanguageStarPrnt', function() {
         let result = encoder.align('right').line('hello').encode();
         
         it('should be [ 32, 32, 32, 32, 32, ..., 10, 13 ]', function () {
-            assert.deepEqual(new Uint8Array([32, 32, 32, 32, 32, 104, 101, 108, 108, 111, 10, 13]), result);
+            assert.deepEqual(new Uint8Array([ 27, 29, 116, 0, 32, 32, 32, 32, 32, 104, 101, 108, 108, 111, 10, 13 ]), result);
         });
     });
 

--- a/test/newlines-in-text.js
+++ b/test/newlines-in-text.js
@@ -1,0 +1,97 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* Calls to text() continue on the same line. A newline character in the text
+   ends the current line, text after it continues on the next line. An empty
+   text does nothing. */
+
+describe('Newlines in text()', function() {
+    const CODEPAGE = [ 27, 116, 0 ];
+    const NL = [ 10, 13 ];
+    const encode = (fn) => fn(new ReceiptPrinterEncoder({ language: 'esc-pos' })).encode();
+
+    describe("text('')", function () {
+        it('should print nothing', function () {
+            assert.deepEqual(new Uint8Array([]), encode((e) => e.text('')));
+        });
+    });
+
+    describe("line('')", function () {
+        it('should print a single empty line', function () {
+            assert.deepEqual(new Uint8Array([ ...NL ]), encode((e) => e.line('')));
+        });
+    });
+
+    describe("line('a').line('').line('b')", function () {
+        it('should print one empty line between a and b', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, ...NL, 98, ...NL ]), encode((e) => e.line('a').line('').line('b')));
+        });
+    });
+
+    describe("text('\\n')", function () {
+        it('should feed once', function () {
+            assert.deepEqual(new Uint8Array([ ...NL ]), encode((e) => e.text('\n')));
+        });
+    });
+
+    describe("text('a\\n')", function () {
+        it('should end the line after a', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL ]), encode((e) => e.text('a\n')));
+        });
+    });
+
+    describe("text('a\\n').text('b')", function () {
+        it('should continue on the next line', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, 98, ...NL ]), encode((e) => e.text('a\n').text('b')));
+        });
+    });
+
+    describe("text('a\\nb')", function () {
+        it('should be the same as text(a).newline().text(b)', function () {
+            assert.deepEqual(encode((e) => e.text('a').newline().text('b')), encode((e) => e.text('a\nb')));
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, 98, ...NL ]), encode((e) => e.text('a\nb')));
+        });
+    });
+
+    describe("text('a\\n\\nb')", function () {
+        it('should keep the empty line in the middle', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, ...NL, 98, ...NL ]), encode((e) => e.text('a\n\nb')));
+        });
+    });
+
+    describe("text('a\\r\\nb')", function () {
+        it('should treat a carriage return and newline as one line break', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, 98, ...NL ]), encode((e) => e.text('a\r\nb')));
+        });
+    });
+
+    describe("text('a').text('b\\nc').text('d')", function () {
+        it('should print ab on the first line and cd on the second', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, 98, ...NL, 99, 100, ...NL ]), encode((e) => e.text('a').text('b\nc').text('d')));
+        });
+    });
+
+    describe("text('a').text('b').text('\\n').text('c').text('d')", function () {
+        it('should print ab on the first line and cd on the second', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, 98, ...NL, 99, 100, ...NL ]), encode((e) => e.text('a').text('b').text('\n').text('c').text('d')));
+        });
+    });
+
+    describe("text('a').text('\\nb')", function () {
+        it('should print a on the first line and b on the second', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...NL, 98, ...NL ]), encode((e) => e.text('a').text('\nb')));
+        });
+    });
+
+    describe("size(2).line('x').size(1).text('').table(...), the workaround from #30", function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 });
+        let result = encoder.size(2).line('x').size(1).text('').table([ { width: 42, align: 'left' } ], [ [ 'y' ] ]).encode();
+
+        it('should apply the style change without printing anything for the empty text', function () {
+            assert.deepEqual(new Uint8Array([
+                29, 33, 17, ...CODEPAGE, 120, 29, 33, 0, ...NL,
+                29, 33, 0, 121, ...new Array(41).fill(32), ...NL,
+            ]), result);
+        });
+    });
+});

--- a/test/newlines-in-text.js
+++ b/test/newlines-in-text.js
@@ -90,7 +90,7 @@ describe('Newlines in text()', function() {
         it('should apply the style change without printing anything for the empty text', function () {
             assert.deepEqual(new Uint8Array([
                 29, 33, 17, ...CODEPAGE, 120, 29, 33, 0, ...NL,
-                29, 33, 0, 121, ...new Array(41).fill(32), ...NL,
+                121, ...new Array(41).fill(32), ...NL,
             ]), result);
         });
     });

--- a/test/redundant-styles.js
+++ b/test/redundant-styles.js
@@ -79,11 +79,9 @@ describe('Redundant style commands', function() {
             .table([ { width: 16, align: 'left' }, { width: 16, align: 'left' } ], [ [ (cell) => cell.bold(true).text('a'), 'b' ] ])
             .encode();
 
-        it('should not repeat bold at the start of the cell, but keep the reset at its end', function () {
-            /* The cell resets bold at its end, so the rest of the row is not bold and the
-               reset of the row itself is redundant. This is how cells behaved before. */
+        it('should not repeat bold inside the cell, the cell inherits it', function () {
             assert.deepEqual(new Uint8Array([
-                ...BOLD_ON, ...CODEPAGE, 97, ...BOLD_OFF, ...new Array(15).fill(32), 98, ...new Array(15).fill(32), ...NL,
+                ...BOLD_ON, ...CODEPAGE, 97, ...new Array(15).fill(32), 98, ...new Array(15).fill(32), ...BOLD_OFF, ...NL,
             ]), result);
         });
     });

--- a/test/redundant-styles.js
+++ b/test/redundant-styles.js
@@ -1,0 +1,90 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* Style commands that set a property to the value the printer already has are
+   left out. Every line starts in the default style. */
+
+describe('Redundant style commands', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const BOLD_ON = [ 27, 69, 1 ];
+    const BOLD_OFF = [ 27, 69, 0 ];
+    const UNDERLINE_ON = [ 27, 45, 1 ];
+    const UNDERLINE_OFF = [ 27, 45, 0 ];
+    const SIZE2 = [ 29, 33, 17 ];
+    const SIZE1 = [ 29, 33, 0 ];
+    const encode = (fn) => fn(new ReceiptPrinterEncoder({ language: 'esc-pos' })).encode();
+
+    describe("bold(true).line(x).bold(false).line(y)", function () {
+        it('should not restore and reset bold at the start of the second line', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 120, ...BOLD_OFF, ...NL, 121, ...NL ]),
+                encode((e) => e.bold(true).line('x').bold(false).line('y')));
+        });
+    });
+
+    describe("size(2).line(x).size(1).line(y)", function () {
+        it('should not send the default size at the start of the second line', function () {
+            assert.deepEqual(new Uint8Array([ ...SIZE2, ...CODEPAGE, 120, ...SIZE1, ...NL, 121, ...NL ]),
+                encode((e) => e.size(2).line('x').size(1).line('y')));
+        });
+    });
+
+    describe("bold(true).line(x).underline(true).line(y)", function () {
+        it('should restore bold and set underline on the second line', function () {
+            assert.deepEqual(new Uint8Array([
+                ...BOLD_ON, ...CODEPAGE, 120, ...BOLD_OFF, ...NL,
+                ...BOLD_ON, ...UNDERLINE_ON, 121, ...BOLD_OFF, ...UNDERLINE_OFF, ...NL,
+            ]), encode((e) => e.bold(true).line('x').underline(true).line('y')));
+        });
+    });
+
+    describe("text(a).bold(true).bold(false).text(b)", function () {
+        it('should not send style commands that cancel each other', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, 98, ...NL ]),
+                encode((e) => e.text('a').bold(true).bold(false).text('b')));
+        });
+    });
+
+    describe("bold(true).text(a).bold(false).text(b)", function () {
+        it('should keep style changes between text', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...BOLD_OFF, 98, ...NL ]),
+                encode((e) => e.bold(true).text('a').bold(false).text('b')));
+        });
+    });
+
+    describe("size(2).text(a).size(1).text(b)", function () {
+        it('should keep size changes between text', function () {
+            assert.deepEqual(new Uint8Array([ ...SIZE2, ...CODEPAGE, 97, ...SIZE1, 98, ...NL ]),
+                encode((e) => e.size(2).text('a').size(1).text('b')));
+        });
+    });
+
+    describe("width(2).height(2).text(a)", function () {
+        it('should collapse consecutive size changes into one', function () {
+            assert.deepEqual(new Uint8Array([ ...SIZE2, ...CODEPAGE, 97, ...SIZE1, ...NL ]),
+                encode((e) => e.width(2).height(2).text('a')));
+        });
+    });
+
+    describe("bold(true).bold(false).bold(true).text(a)", function () {
+        it('should collapse consecutive bold changes into the last one', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...BOLD_OFF, ...NL ]),
+                encode((e) => e.bold(true).bold(false).bold(true).text('a')));
+        });
+    });
+
+    describe("bold(true).table(...) with a bold cell", function () {
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 })
+            .bold(true)
+            .table([ { width: 16, align: 'left' }, { width: 16, align: 'left' } ], [ [ (cell) => cell.bold(true).text('a'), 'b' ] ])
+            .encode();
+
+        it('should not repeat bold at the start of the cell, but keep the reset at its end', function () {
+            /* The cell resets bold at its end, so the rest of the row is not bold and the
+               reset of the row itself is redundant. This is how cells behaved before. */
+            assert.deepEqual(new Uint8Array([
+                ...BOLD_ON, ...CODEPAGE, 97, ...BOLD_OFF, ...new Array(15).fill(32), 98, ...new Array(15).fill(32), ...NL,
+            ]), result);
+        });
+    });
+});

--- a/test/right-alignment.js
+++ b/test/right-alignment.js
@@ -1,0 +1,60 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* A right aligned line drops one trailing space of the text, so that the text
+   ends at the edge of the paper. The padding of table cells and boxes is part
+   of the layout and is never trimmed. */
+
+describe('Right alignment', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const SIZE2 = [ 29, 33, 17 ];
+    const SIZE1 = [ 29, 33, 0 ];
+    const WIDTH1_HEIGHT2 = [ 29, 33, 1 ];
+    const spaces = (n) => new Array(n).fill(32);
+    const encode = (fn, columns = 32) => fn(new ReceiptPrinterEncoder({ language: 'esc-pos', columns })).encode();
+
+    describe("align(right).line('ab ')", function () {
+        it('should trim the trailing space of the text', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...spaces(30), 97, 98, ...NL ]), encode((e) => e.align('right').line('ab ')));
+        });
+    });
+
+    describe('align(right).table() as wide as the paper', function () {
+        it('should not shift the row, the padding of the last cell is kept', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...spaces(15), 98, ...spaces(15), ...NL ]),
+                encode((e) => e.align('right').table([ { width: 16, align: 'left' }, { width: 16, align: 'left' } ], [ [ 'a', 'b' ] ])));
+        });
+    });
+
+    describe('align(right).table() of 20 characters on 32 columns', function () {
+        it('should pad the row on the left by the remaining columns', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...spaces(12), 97, ...spaces(9), 98, ...spaces(9), ...NL ]),
+                encode((e) => e.align('right').table([ { width: 10, align: 'left' }, { width: 10, align: 'left' } ], [ [ 'a', 'b' ] ])));
+        });
+    });
+
+    describe('size(2).align(right).table() of 20 characters on 42 columns', function () {
+        it('should pad the row on the left by the remaining columns of the paper', function () {
+            assert.deepEqual(new Uint8Array([
+                ...spaces(2), ...SIZE2, ...CODEPAGE, 97, ...WIDTH1_HEIGHT2, ...spaces(18), ...SIZE2, 98, ...WIDTH1_HEIGHT2, ...spaces(18), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).align('right').table([ { width: 10, align: 'left' }, { width: 10, align: 'left' } ], [ [ 'a', 'b' ] ]), 42));
+        });
+    });
+
+    describe('align(right).box() with a right margin', function () {
+        it('should keep the margin', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...spaces(20), 104, 105, ...spaces(8), ...spaces(2), ...NL ]),
+                encode((e) => e.align('right').box({ width: 10, style: 'none', align: 'left', marginRight: 2 }, 'hi')));
+        });
+    });
+
+    describe("align(right).line('ab ').table()", function () {
+        it('should trim the text line and not the table row', function () {
+            assert.deepEqual(new Uint8Array([
+                ...CODEPAGE, ...spaces(30), 97, 98, ...NL,
+                ...spaces(22), 99, ...spaces(9), ...NL,
+            ]), encode((e) => e.align('right').line('ab ').table([ { width: 10, align: 'left' } ], [ [ 'c' ] ])));
+        });
+    });
+});

--- a/test/style-inheritance.js
+++ b/test/style-inheritance.js
@@ -1,0 +1,90 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* Table cells and boxes inherit the bold, italic, underline and invert styles
+   that are active when they are created. Style changes inside a cell only
+   apply to that cell. */
+
+describe('Style inheritance in tables and boxes', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const BOLD_ON = [ 27, 69, 1 ];
+    const BOLD_OFF = [ 27, 69, 0 ];
+    const UNDERLINE_ON = [ 27, 45, 1 ];
+    const UNDERLINE_OFF = [ 27, 45, 0 ];
+    const PAD = new Array(7).fill(32);
+    const columns = [ { width: 8, align: 'left' }, { width: 8, align: 'left' }, { width: 8, align: 'left' } ];
+    const table = (row, prepare = (e) => e) => prepare(new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 })).table(columns, [ row ]).encode();
+
+    describe('bold(true).table() with plain cells', function () {
+        it('should print the whole row in bold', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...PAD, 98, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL ]),
+                table([ 'a', 'b', 'c' ], (e) => e.bold(true)));
+        });
+    });
+
+    describe('bold(true).table() with a cell that sets bold(true)', function () {
+        it('should be a no-op, the whole row stays bold', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...PAD, 98, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL ]),
+                table([ 'a', (cell) => cell.bold(true).text('b'), 'c' ], (e) => e.bold(true)));
+        });
+    });
+
+    describe('bold(true).table() with a cell that sets bold(false)', function () {
+        it('should turn bold off for that cell only', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...PAD, ...BOLD_OFF, 98, ...BOLD_ON, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL ]),
+                table([ 'a', (cell) => cell.bold(false).text('b'), 'c' ], (e) => e.bold(true)));
+        });
+    });
+
+    describe('bold(true).table() with a cell that toggles bold()', function () {
+        it('should toggle relative to the inherited style, so bold is off for that cell only', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...PAD, ...BOLD_OFF, 98, ...BOLD_ON, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL ]),
+                table([ 'a', (cell) => cell.bold().text('b'), 'c' ], (e) => e.bold(true)));
+        });
+    });
+
+    describe('bold(true).table() with a cell that sets underline(true)', function () {
+        it('should underline that cell and keep the whole row bold', function () {
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 97, ...PAD, ...UNDERLINE_ON, 98, ...UNDERLINE_OFF, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL ]),
+                table([ 'a', (cell) => cell.underline(true).text('b'), 'c' ], (e) => e.bold(true)));
+        });
+    });
+
+    describe('table() without an outer style, with a cell that sets bold(true)', function () {
+        it('should print only that cell in bold', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...PAD, ...BOLD_ON, 98, ...BOLD_OFF, ...PAD, 99, ...PAD, ...NL ]),
+                table([ 'a', (cell) => cell.bold(true).text('b'), 'c' ]));
+        });
+    });
+
+    describe('bold(true).table().bold(false).line(x)', function () {
+        it('should not leak the style of a cell into the text after the table', function () {
+            let result = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 })
+                .bold(true).table(columns, [ [ 'a', (cell) => cell.bold(false).text('b'), 'c' ] ]).bold(false).line('x').encode();
+
+            assert.deepEqual(new Uint8Array([
+                ...BOLD_ON, ...CODEPAGE, 97, ...PAD, ...BOLD_OFF, 98, ...BOLD_ON, ...PAD, 99, ...PAD, ...BOLD_OFF, ...NL,
+                120, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('bold(true).box() with plain content', function () {
+        it('should print the box content in bold', function () {
+            let result = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 })
+                .bold(true).box({ width: 12, style: 'none', align: 'left' }, 'x').encode();
+
+            assert.deepEqual(new Uint8Array([ ...BOLD_ON, ...CODEPAGE, 120, ...new Array(11).fill(32), ...BOLD_OFF, ...NL ]), result);
+        });
+    });
+
+    describe('bold(true).box() with content that sets bold(false)', function () {
+        it('should print the content plain and the padding after it bold', function () {
+            let result = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 })
+                .bold(true).box({ width: 12, style: 'none', align: 'left' }, (box) => box.bold(false).text('x')).encode();
+
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 120, ...BOLD_ON, ...new Array(11).fill(32), ...BOLD_OFF, ...NL ]), result);
+        });
+    });
+});

--- a/test/styled-blocks.js
+++ b/test/styled-blocks.js
@@ -114,8 +114,7 @@ describe('Styles around cuts, pulses and blocks', function() {
         let result = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).line('hello').bold(false).line('hello').encode();
 
         it('should carry the style state to the next text line without a state-only line in between', function () {
-            /* The second line starts with the restore of the previous style followed by the pending change */
-            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, 27, 69, 1, 27, 69, 0, ...HELLO, ...NL ]), result);
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, ...HELLO, ...NL ]), result);
         });
     });
 });

--- a/test/styled-blocks.js
+++ b/test/styled-blocks.js
@@ -1,0 +1,121 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import ImageData from '@canvas/image-data';
+import { assert } from 'chai';
+
+/* Text styles only apply to text, spaces and raw data. Lines with a cut, a
+   pulse, an image or only pending state changes are not wrapped in style
+   commands, and a cut or pulse is always the first command after a line feed */
+
+describe('Styles around cuts, pulses and blocks', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const STAR_CODEPAGE = [ 27, 29, 116, 0 ];
+    const HELLO = [ 104, 101, 108, 108, 111 ];
+    const CUT = [ 29, 86, 0 ];
+    const PULSE = [ 27, 112, 0, 50, 250 ];
+    const STAR_CUT = [ 27, 100, 0 ];
+    const STAR_PULSE = [ 27, 7, 20, 20, 7 ];
+    const STAR_FLUSH = [ 27, 29, 80, 48, 27, 29, 80, 49 ];
+
+    const image = new ImageData(8, 8);
+    image.data.fill(255);
+
+    describe('bold(true).line(hello).pulse()', function () {
+        let plain = new ReceiptPrinterEncoder({ language: 'esc-pos' }).line('hello').pulse().encode();
+        let styled = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).line('hello').pulse().encode();
+
+        it('should not feed after the pulse, like an unstyled receipt', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...HELLO, ...NL, ...PULSE ]), plain);
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, ...PULSE ]), styled);
+        });
+    });
+
+    describe('bold(true).line(hello).cut()', function () {
+        let styled = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).line('hello').cut().encode();
+
+        it('should send the cut directly after the line feed, without style commands', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, ...CUT, ...NL ]), styled);
+        });
+    });
+
+    describe('bold(true).text(hello).cut()', function () {
+        let styled = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).text('hello').cut().encode();
+
+        it('should end the pending text with a feed before the cut', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, ...CUT, ...NL ]), styled);
+        });
+    });
+
+    describe('bold(true).line(hello).pulse() on star-prnt', function () {
+        let plain = new ReceiptPrinterEncoder({ language: 'star-prnt' }).line('hello').pulse().encode();
+        let styled = new ReceiptPrinterEncoder({ language: 'star-prnt' }).bold(true).line('hello').pulse().encode();
+
+        it('should not append the flush command after the pulse, like an unstyled receipt', function () {
+            assert.deepEqual(new Uint8Array([ ...STAR_CODEPAGE, ...HELLO, ...NL, ...STAR_PULSE ]), plain);
+            assert.deepEqual(new Uint8Array([ 27, 69, ...STAR_CODEPAGE, ...HELLO, 27, 70, ...NL, ...STAR_PULSE ]), styled);
+        });
+    });
+
+    describe('bold(true).line(hello).cut() on star-prnt', function () {
+        let plain = new ReceiptPrinterEncoder({ language: 'star-prnt' }).line('hello').cut().encode();
+        let styled = new ReceiptPrinterEncoder({ language: 'star-prnt' }).bold(true).line('hello').cut().encode();
+
+        it('should not append the flush command after the cut, like an unstyled receipt', function () {
+            assert.deepEqual(new Uint8Array([ ...STAR_CODEPAGE, ...HELLO, ...NL, ...STAR_CUT, ...NL ]), plain);
+            assert.deepEqual(new Uint8Array([ 27, 69, ...STAR_CODEPAGE, ...HELLO, 27, 70, ...NL, ...STAR_CUT, ...NL ]), styled);
+        });
+    });
+
+    describe('bold(true).line(hello) on star-prnt', function () {
+        let styled = new ReceiptPrinterEncoder({ language: 'star-prnt' }).bold(true).line('hello').encode();
+
+        it('should still append the flush command when the receipt does not end in a cut or pulse', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, ...STAR_CODEPAGE, ...HELLO, 27, 70, ...NL, ...STAR_FLUSH, ...NL ]), styled);
+        });
+    });
+
+    describe('bold(true).image(...).line(hello)', function () {
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos', imageMode: 'raster' }).bold(true).image(image, 8, 8).line('hello').encode();
+
+        it('should not wrap the image in style commands, but style the text after it', function () {
+            assert.deepEqual(new Uint8Array([
+                29, 118, 48, 0, 1, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...NL,
+                27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('bold(true).qrcode(x).line(hello)', function () {
+        let plain = new ReceiptPrinterEncoder({ language: 'esc-pos' }).qrcode('x').encode();
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).qrcode('x').line('hello').encode();
+
+        it('should not wrap the qr code in style commands, but style the text after it', function () {
+            assert.deepEqual(new Uint8Array([ ...plain, 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL ]), result);
+        });
+    });
+
+    describe('bold(true).raw(...)', function () {
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).raw([ 104, 105 ]).encode();
+
+        it('should still wrap raw data in style commands', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, 104, 105, 27, 69, 0 ]), result);
+        });
+    });
+
+    describe('bold(true).table(...)', function () {
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 }).bold(true).table([ { width: 32, align: 'left' } ], [ [ 'a' ] ]).encode();
+
+        it('should still wrap table rows in style commands', function () {
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, 97, ...new Array(31).fill(32), 27, 69, 0, ...NL ]), result);
+        });
+    });
+
+    describe('bold(true).line(hello).bold(false).line(hello)', function () {
+        let result = new ReceiptPrinterEncoder({ language: 'esc-pos' }).bold(true).line('hello').bold(false).line('hello').encode();
+
+        it('should carry the style state to the next text line without a state-only line in between', function () {
+            /* The second line starts with the restore of the previous style followed by the pending change */
+            assert.deepEqual(new Uint8Array([ 27, 69, 1, ...CODEPAGE, ...HELLO, 27, 69, 0, ...NL, 27, 69, 1, 27, 69, 0, ...HELLO, ...NL ]), result);
+        });
+    });
+});

--- a/test/table-size.js
+++ b/test/table-size.js
@@ -1,0 +1,97 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import { assert } from 'chai';
+
+/* Column widths are in characters of the size active when the table is created.
+   Cells inherit that size, a size change inside a cell changes how many
+   characters fit, and padding is always printed in single width spaces. */
+
+describe('Size inheritance in tables and boxes', function() {
+    const NL = [ 10, 13 ];
+    const CODEPAGE = [ 27, 116, 0 ];
+    const SIZE2 = [ 29, 33, 17 ];
+    const SIZE1 = [ 29, 33, 0 ];
+    const WIDTH1_HEIGHT2 = [ 29, 33, 1 ];
+    const spaces = (n) => new Array(n).fill(32);
+    const text = (s) => Array.from(s).map((c) => c.charCodeAt(0));
+    const encode = (fn, columns = 32) => fn(new ReceiptPrinterEncoder({ language: 'esc-pos', columns })).encode();
+
+    describe('size(2), a centered column of 9 with 8 characters', function () {
+        it('should pad with one single width space on each side', function () {
+            assert.deepEqual(new Uint8Array([
+                ...WIDTH1_HEIGHT2, 32, ...SIZE2, ...CODEPAGE, ...text('12345678'), ...WIDTH1_HEIGHT2, 32,
+                ...SIZE2, 120, ...WIDTH1_HEIGHT2, ...spaces(12), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).table([ { width: 9, align: 'center' }, { width: 7, align: 'left' } ], [ [ '12345678', 'x' ] ])));
+        });
+    });
+
+    describe('size(2), a column of 10 with 10 characters', function () {
+        it('should fit 10 double width characters', function () {
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, ...text('abcdefghij'), 120, ...WIDTH1_HEIGHT2, ...spaces(10), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).table([ { width: 10, align: 'left' }, { width: 6, align: 'left' } ], [ [ 'abcdefghij', 'x' ] ])));
+        });
+    });
+
+    describe('size(2), a column of 10 with a cell that sets size(1)', function () {
+        it('should fit 20 single width characters', function () {
+            assert.deepEqual(new Uint8Array([
+                ...CODEPAGE, ...text('abcdefghijklmnopqrst'), ...SIZE2, 120, ...WIDTH1_HEIGHT2, ...spaces(10), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).table([ { width: 10, align: 'left' }, { width: 6, align: 'left' } ], [ [ (cell) => cell.size(1).text('abcdefghijklmnopqrst'), 'x' ] ])));
+        });
+    });
+
+    describe('size(2), a cell with double and single width text', function () {
+        it('should count every character at its own width', function () {
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, ...text('ab'), ...SIZE1, ...text('cd'), ...WIDTH1_HEIGHT2, ...spaces(12),
+                ...SIZE2, 120, ...WIDTH1_HEIGHT2, ...spaces(12), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).table([ { width: 9, align: 'left' }, { width: 7, align: 'left' } ], [ [ (cell) => cell.text('ab').size(1).text('cd'), 'x' ] ])));
+        });
+    });
+
+    describe('size(2).align(center), a table of 20 characters on 42 columns', function () {
+        it('should center the row by its width in paper columns', function () {
+            assert.deepEqual(new Uint8Array([
+                32, ...SIZE2, ...CODEPAGE, 97, ...WIDTH1_HEIGHT2, ...spaces(18), ...SIZE2, 98, ...WIDTH1_HEIGHT2, ...spaces(18), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).align('center').table([ { width: 10, align: 'left' }, { width: 10, align: 'left' } ], [ [ 'a', 'b' ] ]), 42));
+        });
+    });
+
+    describe('size(2), a shorter cell next to a two line cell', function () {
+        it('should pad the shorter cell in single width spaces', function () {
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, 97, ...WIDTH1_HEIGHT2, ...spaces(14), ...SIZE2, 120, ...WIDTH1_HEIGHT2, ...spaces(14), ...SIZE1, ...NL,
+                ...SIZE2, 98, ...WIDTH1_HEIGHT2, ...spaces(30), ...SIZE1, ...NL,
+            ]), encode((e) => e.size(2).table([ { width: 8, align: 'left' }, { width: 8, align: 'left' } ], [ [ (cell) => cell.text('a\nb'), 'x' ] ])));
+        });
+    });
+
+    describe('size(2), a table wider than the paper', function () {
+        it('should still throw', function () {
+            assert.throws(() => encode((e) => e.size(2).table([ { width: 17, align: 'left' } ], [ [ 'a' ] ])), 'Table is too wide');
+        });
+    });
+
+    describe('size(2), a box of 16 with a border', function () {
+        it('should draw the borders at double width and pad the content in single width', function () {
+            let result = encode((e) => e.size(2).box({ width: 16, style: 'none', align: 'left' }, 'hi'));
+
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, ...text('hi'), ...WIDTH1_HEIGHT2, ...spaces(28), ...SIZE1, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('size(2), a box wider than the paper', function () {
+        it('should still throw', function () {
+            assert.throws(() => encode((e) => e.size(2).box({ width: 17, style: 'none', align: 'left' }, 'a')), 'Box is too wide');
+        });
+    });
+
+    describe('a table at size 1 with a centered column', function () {
+        it('should pad with plain spaces, without size commands', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...text('12345678'), 32, 120, ...spaces(6), ...NL ]),
+                encode((e) => e.table([ { width: 9, align: 'center' }, { width: 7, align: 'left' } ], [ [ '12345678', 'x' ] ])));
+        });
+    });
+});

--- a/test/table-size.js
+++ b/test/table-size.js
@@ -82,6 +82,32 @@ describe('Size inheritance in tables and boxes', function() {
         });
     });
 
+    describe('size(2), a box of 16 with a single border', function () {
+        it('should draw the borders and the content at double size', function () {
+            let result = encode((e) => e.size(2).box({ width: 16, style: 'single', align: 'left' }, 'hi'));
+            const horizontal = new Array(14).fill(196);
+
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, 218, ...horizontal, 191, ...SIZE1, ...NL,
+                ...SIZE2, 179, ...text('hi'), ...WIDTH1_HEIGHT2, ...spaces(24), ...SIZE2, 179, ...SIZE1, ...NL,
+                ...SIZE2, 192, ...horizontal, 217, ...SIZE1, ...NL,
+            ]), result);
+        });
+    });
+
+    describe('a box at size 1 with content of double height', function () {
+        it('should draw the vertical borders at the height of the content and restore the height', function () {
+            let result = encode((e) => e.box({ width: 16, style: 'single', align: 'left' }, (box) => box.height(2).text('hi')));
+            const horizontal = new Array(14).fill(196);
+
+            assert.deepEqual(new Uint8Array([
+                ...CODEPAGE, 218, ...horizontal, 191, ...NL,
+                ...WIDTH1_HEIGHT2, 179, ...text('hi'), ...SIZE1, ...spaces(12), ...WIDTH1_HEIGHT2, 179, ...SIZE1, ...NL,
+                192, ...horizontal, 217, ...NL,
+            ]), result);
+        });
+    });
+
     describe('size(2), a box wider than the paper', function () {
         it('should still throw', function () {
             assert.throws(() => encode((e) => e.size(2).box({ width: 17, style: 'none', align: 'left' }, 'a')), 'Box is too wide');

--- a/test/table.js
+++ b/test/table.js
@@ -90,6 +90,107 @@ describe('Table width', function() {
     });
 });
 
+describe('Character width inside table cells', function() {
+    const CODEPAGE = [ 27, 116, 0 ];
+    const SIZE2 = [ 29, 33, 17 ];
+    const WIDTH2 = [ 29, 33, 16 ];
+    const HEIGHT2 = [ 29, 33, 1 ];
+    const RESET = [ 29, 33, 0 ];
+    const NL = [ 10, 13 ];
+    const spaces = (n) => new Array(n).fill(32);
+    const text = (s) => Array.from(s).map((c) => c.charCodeAt(0));
+
+    describe('size(2) inside a cell of width 10', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.table(
+            [ { width: 10, align: 'left' }, { width: 2, align: 'left' }, { width: 20, align: 'left' } ],
+            [ [ (cell) => cell.size(2).text('abcdefghijkl'), '', 'next column' ] ],
+        ).encode();
+
+        it('should wrap after 5 characters and keep the other columns aligned', function () {
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, ...text('abcde'), ...RESET, ...spaces(2), ...text('next column'), ...spaces(9), ...NL,
+                ...SIZE2, ...text('fghij'), ...RESET, ...spaces(22), ...NL,
+                ...SIZE2, ...text('kl'), ...RESET, ...spaces(6), ...spaces(22), ...NL,
+            ]), result);
+        });
+    });
+
+    describe('size(2) inside a right aligned cell of width 10', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.table(
+            [ { width: 10, align: 'right' }, { width: 22, align: 'left' } ],
+            [ [ (cell) => cell.size(2).text('abc'), 'next' ] ],
+        ).encode();
+
+        it('should pad with single width spaces', function () {
+            assert.deepEqual(new Uint8Array([
+                ...spaces(4), ...SIZE2, ...CODEPAGE, ...text('abc'), ...RESET, ...text('next'), ...spaces(18), ...NL,
+            ]), result);
+        });
+    });
+
+    describe('width(2) inside a centered cell of width 10', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.table(
+            [ { width: 10, align: 'center' }, { width: 22, align: 'left' } ],
+            [ [ (cell) => cell.width(2).text('abc'), 'next' ] ],
+        ).encode();
+
+        it('should pad with single width spaces on both sides', function () {
+            assert.deepEqual(new Uint8Array([
+                ...spaces(2), ...WIDTH2, ...CODEPAGE, ...text('abc'), ...RESET, ...spaces(2), ...text('next'), ...spaces(18), ...NL,
+            ]), result);
+        });
+    });
+
+    describe('mixed widths inside a cell of width 10', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.table(
+            [ { width: 10, align: 'left' }, { width: 22, align: 'left' } ],
+            [ [ (cell) => cell.text('ab').size(2).text('cde').size(1).text('fghij'), 'next' ] ],
+        ).encode();
+
+        it('should count every character at its own width', function () {
+            assert.deepEqual(new Uint8Array([
+                ...CODEPAGE, ...text('ab'), ...SIZE2, ...text('cde'), ...RESET, ...spaces(2), ...text('next'), ...spaces(18), ...NL,
+                ...text('fghij'), ...spaces(5), ...spaces(22), ...NL,
+            ]), result);
+        });
+    });
+
+    describe('height(2) inside a cell of width 10', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.table(
+            [ { width: 10, align: 'left' }, { width: 22, align: 'left' } ],
+            [ [ (cell) => cell.height(2).text('abcdefghijkl'), 'next' ] ],
+        ).encode();
+
+        it('should wrap after 10 characters, height does not affect the width', function () {
+            assert.deepEqual(new Uint8Array([
+                ...HEIGHT2, ...CODEPAGE, ...text('abcdefghij'), ...RESET, ...text('next'), ...spaces(18), ...NL,
+                ...HEIGHT2, ...text('kl'), ...RESET, ...spaces(8), ...spaces(22), ...NL,
+            ]), result);
+        });
+    });
+
+    describe('size(2) before the table, columns of 5 and 11 characters on 32 columns', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.size(2).table(
+            [ { width: 5, align: 'left' }, { width: 11, align: 'right' } ],
+            [ [ 'abcdefg', '10,00' ] ],
+        ).encode();
+
+        it('should wrap after 5 characters and print the row at double width', function () {
+            assert.deepEqual(new Uint8Array([
+                ...SIZE2, ...CODEPAGE, ...text('abcde'), ...spaces(6), ...text('10,00'), ...RESET, ...NL,
+                ...SIZE2, ...text('fg'), ...spaces(3), ...spaces(11), ...RESET, ...NL,
+                ...RESET,
+            ]), result);
+        });
+    });
+});
+
 describe('LineComposer with content wider than the line', function() {
     for (const align of [ 'left', 'center', 'right' ]) {
         describe(`align ${align}, embedded`, function () {

--- a/test/table.js
+++ b/test/table.js
@@ -75,7 +75,7 @@ describe('Table width', function() {
         let result = encoder.size(2).table([ { width: 15, align: 'left' }, { width: 6, align: 'right' } ], [ [ 'a', 'b' ] ]).encode();
 
         it('should print the table at double width', function () {
-            assert.deepEqual(new Uint8Array([ 29, 33, 17, ...CODEPAGE, 97, ...spaces(14), ...spaces(5), 98, 29, 33, 0, ...NL, 29, 33, 0 ]), result);
+            assert.deepEqual(new Uint8Array([ 29, 33, 17, ...CODEPAGE, 97, ...spaces(14), ...spaces(5), 98, 29, 33, 0, ...NL ]), result);
         });
     });
 
@@ -185,7 +185,6 @@ describe('Character width inside table cells', function() {
             assert.deepEqual(new Uint8Array([
                 ...SIZE2, ...CODEPAGE, ...text('abcde'), ...spaces(6), ...text('10,00'), ...RESET, ...NL,
                 ...SIZE2, ...text('fg'), ...spaces(3), ...spaces(11), ...RESET, ...NL,
-                ...RESET,
             ]), result);
         });
     });

--- a/test/table.js
+++ b/test/table.js
@@ -1,0 +1,119 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import LineComposer from '../src/line-composer.js';
+import { assert, expect } from 'chai';
+
+/* A table wider than the paper crashed with a RangeError when centered and
+   overflowed silently when left aligned, see #62 and #59 */
+
+describe('Table width', function() {
+    const CODEPAGE = [ 27, 116, 0 ];
+    const NL = [ 10, 13 ];
+    const spaces = (n) => new Array(n).fill(32);
+
+    describe('table() as wide as the paper', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 });
+        let result = encoder.table([ { width: 20, align: 'left' }, { width: 22, align: 'right' } ], [ [ 'a', 'b' ] ]).encode();
+
+        it('should fill the line', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...spaces(19), ...spaces(21), 98, ...NL ]), result);
+        });
+    });
+
+    describe('table() with margins as wide as the paper', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 });
+        let result = encoder.table([ { width: 20, marginRight: 2, align: 'left' }, { width: 18, marginLeft: 2, align: 'right' } ], [ [ 'a', 'b' ] ]).encode();
+
+        it('should fill the line', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, 97, ...spaces(19), ...spaces(2), ...spaces(2), ...spaces(17), 98, ...NL ]), result);
+        });
+    });
+
+    describe('align(center).bold(true).line(...).table() wider than the paper, as in #62', function () {
+        it('should throw a descriptive error instead of a RangeError', function () {
+            expect(function () {
+                new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 })
+                    .align('center').bold(true).line('--------')
+                    .table([
+                        { width: 20, align: 'left' },
+                        { width: 6, align: 'left' },
+                        { width: 20, align: 'right' },
+                    ], [ [ 'a', 'b', 'c' ] ]);
+            }).to.throw('Table is too wide');
+        });
+    });
+
+    describe('table() one column wider than the paper, left aligned', function () {
+        it('should throw instead of overflowing silently', function () {
+            expect(function () {
+                new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 })
+                    .table([ { width: 20, align: 'left' }, { width: 23, align: 'right' } ], [ [ 'a', 'b' ] ]);
+            }).to.throw('Table is too wide');
+        });
+    });
+
+    describe('table() with margins wider than the paper', function () {
+        it('should include the margins in the width', function () {
+            expect(function () {
+                new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 })
+                    .table([ { width: 20, marginRight: 3, align: 'left' }, { width: 20, align: 'right' } ], [ [ 'a', 'b' ] ]);
+            }).to.throw('Table is too wide');
+        });
+    });
+
+    describe('size(2).table() wider than half the paper, as in #59', function () {
+        it('should include the character width in the width', function () {
+            expect(function () {
+                new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 })
+                    .size(2)
+                    .table([ { width: 16, align: 'left' }, { width: 6, align: 'right' } ], [ [ 'a', 'b' ] ]);
+            }).to.throw('Table is too wide');
+        });
+    });
+
+    describe('size(2).table() that fits half the paper', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 });
+        let result = encoder.size(2).table([ { width: 15, align: 'left' }, { width: 6, align: 'right' } ], [ [ 'a', 'b' ] ]).encode();
+
+        it('should print the table at double width', function () {
+            assert.deepEqual(new Uint8Array([ 29, 33, 17, ...CODEPAGE, 97, ...spaces(14), ...spaces(5), 98, 29, 33, 0, ...NL, 29, 33, 0 ]), result);
+        });
+    });
+
+    describe('width(2).table() that fits half the paper', function () {
+        it('should use the character width, not the height', function () {
+            expect(function () {
+                new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 })
+                    .height(2)
+                    .table([ { width: 20, align: 'left' }, { width: 22, align: 'right' } ], [ [ 'a', 'b' ] ]);
+            }).to.not.throw();
+        });
+    });
+});
+
+describe('LineComposer with content wider than the line', function() {
+    for (const align of [ 'left', 'center', 'right' ]) {
+        describe(`align ${align}, embedded`, function () {
+            const lines = [];
+            const composer = new LineComposer({ embedded: true, columns: 10, align, size: 1, callback: (line) => lines.push(line) });
+            composer.add({ type: 'text', value: 'x'.repeat(12), codepage: null }, 12);
+            composer.flush();
+
+            it('should not produce negative padding', function () {
+                assert.equal(lines.length, 1);
+                assert.deepEqual(lines[0], [ { type: 'text', value: 'x'.repeat(12), codepage: null } ]);
+            });
+        });
+
+        describe(`align ${align}, not embedded`, function () {
+            const lines = [];
+            const composer = new LineComposer({ embedded: false, columns: 10, align, size: 1, callback: (line) => lines.push(line) });
+            composer.add({ type: 'text', value: 'x'.repeat(12), codepage: null }, 12);
+            composer.flush();
+
+            it('should not produce negative padding', function () {
+                assert.equal(lines.length, 1);
+                assert.deepEqual(lines[0], [ { type: 'text', value: 'x'.repeat(12), codepage: null } ]);
+            });
+        });
+    }
+});

--- a/test/table.js
+++ b/test/table.js
@@ -74,8 +74,10 @@ describe('Table width', function() {
         let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 42 });
         let result = encoder.size(2).table([ { width: 15, align: 'left' }, { width: 6, align: 'right' } ], [ [ 'a', 'b' ] ]).encode();
 
-        it('should print the table at double width', function () {
-            assert.deepEqual(new Uint8Array([ 29, 33, 17, ...CODEPAGE, 97, ...spaces(14), ...spaces(5), 98, 29, 33, 0, ...NL ]), result);
+        it('should print the table at double width, padded with single width spaces', function () {
+            assert.deepEqual(new Uint8Array([
+                29, 33, 17, ...CODEPAGE, 97, 29, 33, 1, ...spaces(28), ...spaces(10), 29, 33, 17, 98, 29, 33, 0, ...NL,
+            ]), result);
         });
     });
 
@@ -183,8 +185,8 @@ describe('Character width inside table cells', function() {
 
         it('should wrap after 5 characters and print the row at double width', function () {
             assert.deepEqual(new Uint8Array([
-                ...SIZE2, ...CODEPAGE, ...text('abcde'), ...spaces(6), ...text('10,00'), ...RESET, ...NL,
-                ...SIZE2, ...text('fg'), ...spaces(3), ...spaces(11), ...RESET, ...NL,
+                ...SIZE2, ...CODEPAGE, ...text('abcde'), ...HEIGHT2, ...spaces(12), ...SIZE2, ...text('10,00'), ...RESET, ...NL,
+                ...SIZE2, ...text('fg'), ...HEIGHT2, ...spaces(6), ...spaces(22), ...RESET, ...NL,
             ]), result);
         });
     });

--- a/test/text-wrap.js
+++ b/test/text-wrap.js
@@ -1,0 +1,159 @@
+import ReceiptPrinterEncoder from '../src/receipt-printer-encoder.js';
+import TextWrap from '../src/text-wrap.js';
+import { assert } from 'chai';
+
+/* Whitespace between words is a separator that becomes the newline when the
+   line wraps, whitespace before or after the words is literal, see #65 */
+
+describe('TextWrap', function() {
+    const wrap = (value, options) => TextWrap.wrap(value, Object.assign({ columns: 7 }, options));
+
+    describe('separators', function () {
+        it('should drop the separator that becomes the newline', function () {
+            assert.deepEqual(wrap('One Two Three Four'), [ 'One Two', 'Three', 'Four' ]);
+        });
+
+        it('should drop the whole separator, however wide', function () {
+            assert.deepEqual(wrap('One   Two   Three'), [ 'One', 'Two', 'Three' ]);
+        });
+
+        it('should print separators that do not cause a wrap', function () {
+            assert.deepEqual(wrap('a   b'), [ 'a   b' ]);
+        });
+
+        it('should print aligned columns when the line fits', function () {
+            assert.deepEqual(wrap('Item      1.00', { columns: 14 }), [ 'Item      1.00' ]);
+        });
+
+        it('should take the character width into account', function () {
+            assert.deepEqual(wrap('One Two Three', { columns: 14, width: 2 }), [ 'One Two', 'Three' ]);
+        });
+    });
+
+    describe('literal whitespace', function () {
+        it('should keep whitespace at the start of the text', function () {
+            assert.deepEqual(wrap('  One Two'), [ '  One', 'Two' ]);
+        });
+
+        it('should keep whitespace at the start of an explicit line', function () {
+            assert.deepEqual(wrap('One\n  Two'), [ 'One', '  Two' ]);
+        });
+
+        it('should keep whitespace at the end of the text', function () {
+            assert.deepEqual(wrap('One '), [ 'One ' ]);
+        });
+
+        it('should keep whitespace at the end of an explicit line', function () {
+            assert.deepEqual(wrap('One \nTwo'), [ 'One ', 'Two' ]);
+        });
+
+        it('should clip trailing whitespace at the edge of the line', function () {
+            assert.deepEqual(wrap('One Two   '), [ 'One Two' ]);
+        });
+
+        it('should clip leading whitespace at the edge of the line', function () {
+            assert.deepEqual(wrap('          One'), [ '       ', 'One' ]);
+        });
+
+        it('should keep a line of only whitespace', function () {
+            assert.deepEqual(wrap('   '), [ '   ' ]);
+        });
+    });
+
+    describe('continuing an existing line', function () {
+        it('should treat leading whitespace as a separator when the word fits', function () {
+            assert.deepEqual(wrap('   b', { columns: 5, indent: 1 }), [ '   b' ]);
+        });
+
+        it('should drop leading whitespace as a separator when the word wraps', function () {
+            assert.deepEqual(wrap('   b', { columns: 4, indent: 1 }), [ '', 'b' ]);
+        });
+
+        it('should keep leading whitespace without a word, clipped', function () {
+            assert.deepEqual(wrap('     ', { columns: 4, indent: 1 }), [ '   ' ]);
+        });
+
+        it('should only apply the indent to the first line', function () {
+            assert.deepEqual(wrap('b\n  c', { columns: 4, indent: 1 }), [ 'b', '  c' ]);
+        });
+    });
+
+    describe('non-breaking spaces', function () {
+        it('should keep non-breaking spaces at the start of the text', function () {
+            assert.deepEqual(wrap('  One'), [ '  One' ]);
+        });
+
+        it('should not wrap at a non-breaking space', function () {
+            assert.deepEqual(wrap('One Two Three'), [ 'One Two', 'Three' ]);
+        });
+
+        it('should keep non-breaking spaces at the end of a line', function () {
+            assert.deepEqual(wrap('One \nTwo'), [ 'One ', 'Two' ]);
+        });
+    });
+
+    describe('other behaviour', function () {
+        it('should return a single empty line for an empty string', function () {
+            assert.deepEqual(wrap(''), [ '' ]);
+        });
+
+        it('should keep explicit empty lines', function () {
+            assert.deepEqual(wrap('a\n\nb'), [ 'a', '', 'b' ]);
+        });
+
+        it('should split words longer than the line', function () {
+            assert.deepEqual(wrap('abcdefghijklmnop'), [ 'abcdefg', 'hijklmn', 'op' ]);
+        });
+
+        it('should start a long word on the current line when enough space remains', function () {
+            assert.deepEqual(wrap('ab abcdefghijklmnopqrstuvwxyz', { columns: 20 }), [ 'ab abcdefghijklmnopq', 'rstuvwxyz' ]);
+        });
+
+        it('should allow a break after a hyphen', function () {
+            assert.deepEqual(wrap('One Two-Three'), [ 'One', 'Two-', 'Three' ]);
+            assert.deepEqual(wrap('Two-Three', { columns: 9 }), [ 'Two-Three' ]);
+        });
+    });
+});
+
+describe('Whitespace in text() and line()', function() {
+    const CODEPAGE = [ 27, 116, 0 ];
+    const NL = [ 10, 13 ];
+    const spaces = (n) => new Array(n).fill(32);
+
+    describe('line("    Left padded")', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.line('    Left padded').encode();
+
+        it('should print the leading spaces, see #65', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...spaces(4), 76, 101, 102, 116, 32, 112, 97, 100, 100, 101, 100, ...NL ]), result);
+        });
+    });
+
+    describe('codepage(windows1252).line("\\u00a0\\u00a0Left padded")', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos' });
+        let result = encoder.codepage('windows1252').line('  Left padded').encode();
+
+        it('should print the leading non-breaking spaces, see #65', function () {
+            assert.deepEqual(new Uint8Array([ 27, 116, 16, 160, 160, 76, 101, 102, 116, 32, 112, 97, 100, 100, 101, 100, ...NL ]), result);
+        });
+    });
+
+    describe('text(a).text("   b") on a 32 column line that wraps', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.text('a'.repeat(30)).text('   b').encode();
+
+        it('should drop the separator and wrap the word', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...new Array(30).fill(97), ...NL, 98, ...NL ]), result);
+        });
+    });
+
+    describe('text("a   ").text(b) on a 32 column line that wraps', function () {
+        let encoder = new ReceiptPrinterEncoder({ language: 'esc-pos', columns: 32 });
+        let result = encoder.text('a'.repeat(30) + '   ').text('b').encode();
+
+        it('should keep the trailing whitespace, clipped, and wrap the word', function () {
+            assert.deepEqual(new Uint8Array([ ...CODEPAGE, ...new Array(30).fill(97), 32, 32, ...NL, 98, ...NL ]), result);
+        });
+    });
+});


### PR DESCRIPTION
Fixes and improvements from a review of the open bug reports. Every change has tests, `npm test` is green (212 tests, lint without errors) on Node 20 and Node 22.

## Baseline

- Update the expected bytes in the language tests for the codepage command that has been emitted before the first text since #49. 33 tests failed on `main` because of this.
- Make the linter pass so `npm test` runs through to mocha.
- Update the `canvas` dev dependency to version 3, which has prebuilt binaries for Node 22.

## Fixes

- **#63** No line feed after lines that only change printer state. A pending style, font or alignment change before an image, barcode, QR code or cut printed as an empty line, and so did the trailing style reset at the end of a receipt. `raw()` is not considered content, so a lone `raw()` is no longer followed by a line feed. Also fixes the line feed before the drawer kick in `initialize().codepage().pulse()`.
- **#57** The initialize command is sent before the alignment padding, so alignment works on the first line.
- **#65** Leading whitespace is kept, non-breaking spaces are part of words. Whitespace between words is a separator that becomes the newline when the line wraps, whitespace before or after the words is literal.
- **#62, #59** A table wider than the paper, including margins and the current character width, throws `Table is too wide` instead of a `RangeError` or a silent overflow. Negative padding in the composer is clamped.
- **#47** The motion unit is set explicitly with `GS P` around column mode images when the printer model is known, so `ESC 3 24` is 24 dots on every printer. Without a printer model only `ESC 3 24` is sent. Needs physical verification on the available printers, with column mode forced.
- **#44** Documented the `structuredClone` polyfill for React Native and Expo.
- **#43** New `feedAfterBlock` option, default `true` to keep existing output. With `false` no line feed is sent after images, barcodes, QR codes and PDF417 codes.

## Behaviour of text and styles

- A newline in `text()` ends the line, text after it continues on the next line. `text('')` prints nothing, `line('')` feeds once instead of twice.
- Style commands are only emitted on lines with text, spaces or raw data, and style commands that set the state the printer already has are left out. Cuts, pulses and images are no longer wrapped in style commands, which also makes the checks that suppress the flush and feed after a final cut or pulse work for styled receipts.
- Table cells and boxes inherit bold, italic, underline, invert and the size. A style set inside a cell applies to that cell only. Column and box widths are in characters of the size active when the table or box is created, a cell that changes the size fits more or fewer characters, and padding is done in single width spaces.
- A right aligned line only trims a trailing space of typed text, the padding of tables and boxes is kept. Boxes restore the current height after their vertical borders.

## Documentation

- Table and box sections describe character widths and style inheritance, `text()` describes newlines, configuration describes `feedAfterBlock`, usage describes React Native and Expo, and a stray string in the box example is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RF1GAwMGZo1n1ziEFg2V8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF1GAwMGZo1n1ziEFg2V8d)_